### PR TITLE
start replacing unwraps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,21 +25,20 @@ Generally working but there are probably bugs lingering. Need to setup fuzzing a
 There are some examples in the `examples/` directory but the gist is:
 ```
 // Connect to the session bus
-let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
+let session_path = rustbus::client_conn::get_session_bus_path()?;
+let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
 
 // Wrap the con in an RpcConnection which provides many convenient functions
 let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
 
 // send the obligatory hello message
-rpc_con.send_message(standard_messages::hello()).unwrap();
+rpc_con.send_message(standard_messages::hello())?;
 
 // Request a bus name if you want to
 rpc_con.send_message(standard_messages::request_name(
     "io.killing.spark".into(),
     0,
-))
-.unwrap();
+))?;
 
 // send a signal to all bus members
 let sig = MessageBuilder::new()
@@ -59,5 +58,5 @@ let sig = MessageBuilder::new()
     Container::Dict(dict).into(),
 ])
 .build();
-con.send_message(sig).unwrap();
+con.send_message(sig)?;
 ```

--- a/examples/con.rs
+++ b/examples/con.rs
@@ -1,10 +1,9 @@
-extern crate rustbus;
 use rustbus::message;
 use rustbus::standard_messages;
 
-fn main() {
-    let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-    let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
+fn main() -> Result<(), rustbus::client_conn::Error> {
+    let session_path = rustbus::client_conn::get_session_bus_path()?;
+    let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
     let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
 
     let hello_msg = standard_messages::hello();
@@ -18,13 +17,13 @@ fn main() {
     }));
 
     println!("Send message: {:?}", hello_msg);
-    let hello_serial = rpc_con.send_message(hello_msg).unwrap().serial.unwrap();
+    let hello_serial = rpc_con.send_message(hello_msg)?.serial.unwrap();
 
     println!("\n");
     println!("\n");
     println!("\n");
     println!("Wait for hello response");
-    let msg = rpc_con.wait_response(hello_serial).unwrap();
+    let msg = rpc_con.wait_response(hello_serial)?;
     println!("Got response: {:?}", msg);
     println!("\n");
     println!("\n");
@@ -34,13 +33,12 @@ fn main() {
         .send_message(standard_messages::request_name(
             "io.killing.spark".into(),
             0,
-        ))
-        .unwrap()
+        ))?
         .serial
         .unwrap();
 
     println!("Wait for name request response");
-    let msg = rpc_con.wait_response(reqname_serial).unwrap();
+    let msg = rpc_con.wait_response(reqname_serial)?;
     println!("Got response: {:?}", msg);
     println!("\n");
     println!("\n");
@@ -58,13 +56,12 @@ fn main() {
     }
 
     let list_serial = rpc_con
-        .send_message(standard_messages::list_names())
-        .unwrap()
+        .send_message(standard_messages::list_names())?
         .serial
         .unwrap();
 
     println!("Wait for list response");
-    let msg = rpc_con.wait_response(list_serial).unwrap();
+    let msg = rpc_con.wait_response(list_serial)?;
     println!("Got response: {:?}", msg);
     println!("\n");
     println!("\n");
@@ -73,11 +70,11 @@ fn main() {
     let sig_listen_msg = standard_messages::add_match("type='signal'".into());
 
     println!("Send message: {:?}", sig_listen_msg);
-    rpc_con.send_message(sig_listen_msg).unwrap();
+    rpc_con.send_message(sig_listen_msg)?;
 
     loop {
         println!("Wait for incoming signals");
-        let msg = rpc_con.wait_signal().unwrap();
+        let msg = rpc_con.wait_signal()?;
         println!("Got signal: {:?}", msg);
         loop {
             let msg = rpc_con.try_get_signal();

--- a/examples/con.rs
+++ b/examples/con.rs
@@ -1,19 +1,18 @@
-use rustbus::message;
-use rustbus::standard_messages;
+use rustbus::{get_session_bus_path, standard_messages, Conn, MessageType, RpcConn};
 
 fn main() -> Result<(), rustbus::client_conn::Error> {
-    let session_path = rustbus::client_conn::get_session_bus_path()?;
-    let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
-    let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
+    let session_path = get_session_bus_path()?;
+    let con = Conn::connect_to_bus(session_path, true)?;
+    let mut rpc_con = RpcConn::new(con);
 
     let hello_msg = standard_messages::hello();
 
     rpc_con.set_filter(Box::new(|msg| match msg.typ {
-        message::MessageType::Call => false,
-        message::MessageType::Invalid => false,
-        message::MessageType::Error => true,
-        message::MessageType::Reply => true,
-        message::MessageType::Signal => msg.sender.eq(&Some("org.freedesktop.DBus".to_owned())),
+        MessageType::Call => false,
+        MessageType::Invalid => false,
+        MessageType::Error => true,
+        MessageType::Reply => true,
+        MessageType::Signal => msg.sender.eq(&Some("org.freedesktop.DBus".to_owned())),
     }));
 
     println!("Send message: {:?}", hello_msg);

--- a/examples/fd.rs
+++ b/examples/fd.rs
@@ -1,4 +1,3 @@
-extern crate rustbus;
 use rustbus::message_builder::MessageBuilder;
 use rustbus::standard_messages;
 

--- a/examples/fd.rs
+++ b/examples/fd.rs
@@ -1,5 +1,4 @@
-use rustbus::message_builder::MessageBuilder;
-use rustbus::standard_messages;
+use rustbus::{get_session_bus_path, standard_messages, Conn, MessageBuilder, RpcConn};
 
 use std::io::Write;
 use std::os::unix::io::FromRawFd;
@@ -11,10 +10,10 @@ fn main() -> Result<(), rustbus::client_conn::Error> {
     {
         send_fd()?;
     } else {
-        let session_path = rustbus::client_conn::get_session_bus_path()?;
-        let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
-        let mut con = rustbus::client_conn::RpcConn::new(con);
-        con.send_message(rustbus::standard_messages::hello())?;
+        let session_path = get_session_bus_path()?;
+        let con = Conn::connect_to_bus(session_path, true)?;
+        let mut con = RpcConn::new(con);
+        con.send_message(standard_messages::hello())?;
 
         con.send_message(standard_messages::add_match("type='signal'".into()))?;
 

--- a/examples/fd.rs
+++ b/examples/fd.rs
@@ -5,24 +5,22 @@ use rustbus::standard_messages;
 use std::io::Write;
 use std::os::unix::io::FromRawFd;
 
-fn main() {
+fn main() -> Result<(), rustbus::client_conn::Error> {
     if std::env::args()
         .collect::<Vec<_>>()
         .contains(&"send".to_owned())
     {
-        send_fd();
+        send_fd()?;
     } else {
-        let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-        let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
+        let session_path = rustbus::client_conn::get_session_bus_path()?;
+        let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
         let mut con = rustbus::client_conn::RpcConn::new(con);
-        con.send_message(rustbus::standard_messages::hello())
-            .unwrap();
+        con.send_message(rustbus::standard_messages::hello())?;
 
-        con.send_message(standard_messages::add_match("type='signal'".into()))
-            .unwrap();
+        con.send_message(standard_messages::add_match("type='signal'".into()))?;
 
         let sig = loop {
-            let signal = con.wait_signal().unwrap();
+            let signal = con.wait_signal()?;
             println!("Got signal: {:?}", signal);
             if signal.interface.eq(&Some("io.killing.spark".to_owned())) {
                 if signal.member.eq(&Some("TestSignal".to_owned())) {
@@ -33,15 +31,16 @@ fn main() {
 
         println!("Got signal: {:?}", sig);
         let mut file = unsafe { std::fs::File::from_raw_fd(sig.raw_fds[0]) };
-        file.write_all(b"This is a line\n").unwrap();
+        file.write_all(b"This is a line\n")?;
     }
+
+    Ok(())
 }
 
-fn send_fd() {
-    let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-    let mut con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
-    con.send_message(rustbus::standard_messages::hello())
-        .unwrap();
+fn send_fd() -> Result<(), rustbus::client_conn::Error> {
+    let session_path = rustbus::client_conn::get_session_bus_path()?;
+    let mut con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
+    con.send_message(rustbus::standard_messages::hello())?;
     let mut sig = MessageBuilder::new()
         .signal(
             "io.killing.spark".into(),
@@ -52,7 +51,7 @@ fn send_fd() {
 
     sig.raw_fds.push(0);
     sig.num_fds = Some(1);
-    con.send_message(sig).unwrap();
+    con.send_message(sig)?;
 
     let sig = MessageBuilder::new()
         .signal(
@@ -61,13 +60,13 @@ fn send_fd() {
             "/io/killing/spark".into(),
         )
         .build();
-    con.send_message(sig).unwrap();
+    con.send_message(sig)?;
 
     println!("Printing stuff fromn stdin");
     let mut line = String::new();
     loop {
         line.clear();
-        std::io::stdin().read_line(&mut line).unwrap();
+        std::io::stdin().read_line(&mut line)?;
         println!("Line: {}", line);
     }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,4 +1,3 @@
-extern crate rustbus;
 use rustbus::message;
 use rustbus::standard_messages;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -25,22 +25,21 @@ impl Commands {
     }
 }
 
-fn main() {
-    let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-    let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
+fn main() -> Result<(), rustbus::client_conn::Error> {
+    let session_path = rustbus::client_conn::get_session_bus_path()?;
+    let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
     let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
 
-    rpc_con.send_message(standard_messages::hello()).unwrap();
+    rpc_con.send_message(standard_messages::hello())?;
 
     let namereq_serial = rpc_con
         .send_message(standard_messages::request_name(
             "io.killing.spark".into(),
             0,
-        ))
-        .unwrap()
+        ))?
         .serial
         .unwrap();
-    let resp = rpc_con.wait_response(namereq_serial).unwrap();
+    let resp = rpc_con.wait_response(namereq_serial)?;
     println!("Name request response: {:?}", resp);
 
     rpc_con.set_filter(Box::new(|msg| match msg.typ {
@@ -67,7 +66,7 @@ fn main() {
 
     loop {
         println!("Wait for call");
-        let call = rpc_con.wait_call().unwrap();
+        let call = rpc_con.wait_call()?;
         println!("Got call: {:?}", call);
         if let Some(member) = &call.member {
             let cmd = match member.as_str() {
@@ -75,30 +74,26 @@ fn main() {
                 "Reverse" => {
                     if call.params.len() != 1 {
                         rpc_con
-                            .send_message(standard_messages::invalid_args(&call, Some("String")))
-                            .unwrap();
+                            .send_message(standard_messages::invalid_args(&call, Some("String")))?;
                         continue;
                     }
                     if let message::Param::Base(message::Base::String(val)) = &call.params[0] {
                         Commands::Reverse(val.clone())
                     } else {
                         rpc_con
-                            .send_message(standard_messages::invalid_args(&call, Some("String")))
-                            .unwrap();
+                            .send_message(standard_messages::invalid_args(&call, Some("String")))?;
                         continue;
                     }
                 }
                 _ => {
                     // This shouldn't happen with the filters defined above
-                    rpc_con
-                        .send_message(standard_messages::unknown_method(&call))
-                        .unwrap();
+                    rpc_con.send_message(standard_messages::unknown_method(&call))?;
                     continue;
                 }
             };
             let reply = cmd.execute(&call);
             println!("Reply: {:?}", reply);
-            rpc_con.send_message(reply).unwrap();
+            rpc_con.send_message(reply)?;
             println!("Reply sent");
         }
     }

--- a/examples/sig.rs
+++ b/examples/sig.rs
@@ -1,4 +1,3 @@
-extern crate rustbus;
 use rustbus::message::Container;
 use rustbus::message::DictMap;
 use rustbus::message_builder::MessageBuilder;

--- a/examples/sig.rs
+++ b/examples/sig.rs
@@ -1,11 +1,9 @@
-use rustbus::message::Container;
-use rustbus::message::DictMap;
-use rustbus::message_builder::MessageBuilder;
+use rustbus::{get_session_bus_path, standard_messages, Conn, Container, DictMap, MessageBuilder};
 
 fn main() -> Result<(), rustbus::client_conn::Error> {
-    let session_path = rustbus::client_conn::get_session_bus_path()?;
-    let mut con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
-    con.send_message(rustbus::standard_messages::hello())?;
+    let session_path = get_session_bus_path()?;
+    let mut con = Conn::connect_to_bus(session_path, true)?;
+    con.send_message(standard_messages::hello())?;
 
     let mut dict = DictMap::new();
     dict.insert("Key1".to_owned().into(), 100i32.into());

--- a/examples/sig.rs
+++ b/examples/sig.rs
@@ -3,11 +3,10 @@ use rustbus::message::Container;
 use rustbus::message::DictMap;
 use rustbus::message_builder::MessageBuilder;
 
-fn main() {
-    let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-    let mut con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
-    con.send_message(rustbus::standard_messages::hello())
-        .unwrap();
+fn main() -> Result<(), rustbus::client_conn::Error> {
+    let session_path = rustbus::client_conn::get_session_bus_path()?;
+    let mut con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
+    con.send_message(rustbus::standard_messages::hello())?;
 
     let mut dict = DictMap::new();
     dict.insert("Key1".to_owned().into(), 100i32.into());
@@ -30,6 +29,8 @@ fn main() {
             Container::Dict(dict).into(),
         ])
         .build();
-    con.send_message(sig.clone()).unwrap();
-    con.send_message(sig).unwrap();
+    con.send_message(sig.clone())?;
+    con.send_message(sig)?;
+
+    Ok(())
 }

--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -35,31 +35,35 @@ pub struct RpcConn {
 /// ```rust,no_run
 /// use rustbus::message;
 ///
-/// let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-/// let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
-/// let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
+/// fn main() -> Result<(), rustbus::client_conn::Error> {
+///     let session_path = rustbus::client_conn::get_session_bus_path()?;
+///     let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
+///     let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
 ///
-/// rpc_con.set_filter(Box::new(|msg| match msg.typ {
-/// message::MessageType::Call => {
-///     let right_interface_object = msg.object.eq(&Some("/io/killing/spark".into()))
-///         && msg.interface.eq(&Some("io.killing.spark".into()));
+///     rpc_con.set_filter(Box::new(|msg| match msg.typ {
+///     message::MessageType::Call => {
+///         let right_interface_object = msg.object.eq(&Some("/io/killing/spark".into()))
+///             && msg.interface.eq(&Some("io.killing.spark".into()));
 ///
-///     let right_member = if let Some(member) = &msg.member {
-///         member.eq("Echo") || member.eq("Reverse")
-///     } else {
-///         false
-///     };
-///     let keep = right_interface_object && right_member;
-///     if !keep {
-///         println!("Discard: {:?}", msg);
+///         let right_member = if let Some(member) = &msg.member {
+///             member.eq("Echo") || member.eq("Reverse")
+///         } else {
+///             false
+///         };
+///         let keep = right_interface_object && right_member;
+///         if !keep {
+///             println!("Discard: {:?}", msg);
+///         }
+///         keep
 ///     }
-///     keep
-/// }
-/// message::MessageType::Invalid => false,
-/// message::MessageType::Error => true,
-/// message::MessageType::Reply => true,
-/// message::MessageType::Signal => false,
+///     message::MessageType::Invalid => false,
+///     message::MessageType::Error => true,
+///     message::MessageType::Reply => true,
+///     message::MessageType::Signal => false,
 /// }));
+///
+/// Ok(())
+/// }
 /// ```
 pub type MessageFilter = dyn Fn(&message::Message) -> bool;
 
@@ -376,8 +380,7 @@ impl Conn {
             &[ControlMessage::ScmRights(&msg.raw_fds)],
             flags,
             None,
-        )
-        .unwrap();
+        )?;
         assert_eq!(l, self.msg_buf_out.len());
         Ok(msg)
     }

--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -34,15 +34,15 @@ pub struct RpcConn {
 /// If this filters out a call, the RpcConn will send a UnknownMethod error to the caller. Other messages are just dropped
 /// if the filter returns false.
 /// ```rust,no_run
-/// use rustbus::message;
+/// use rustbus::{get_session_bus_path, standard_messages, Conn, Container, DictMap, MessageBuilder, MessageType, RpcConn};
 ///
 /// fn main() -> Result<(), rustbus::client_conn::Error> {
-///     let session_path = rustbus::client_conn::get_session_bus_path()?;
-///     let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
-///     let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
+///     let session_path = get_session_bus_path()?;
+///     let con = Conn::connect_to_bus(session_path, true)?;
+///     let mut rpc_con = RpcConn::new(con);
 ///
 ///     rpc_con.set_filter(Box::new(|msg| match msg.typ {
-///     message::MessageType::Call => {
+///     MessageType::Call => {
 ///         let right_interface_object = msg.object.eq(&Some("/io/killing/spark".into()))
 ///             && msg.interface.eq(&Some("io.killing.spark".into()));
 ///
@@ -57,10 +57,10 @@ pub struct RpcConn {
 ///         }
 ///         keep
 ///     }
-///     message::MessageType::Invalid => false,
-///     message::MessageType::Error => true,
-///     message::MessageType::Reply => true,
-///     message::MessageType::Signal => false,
+///     MessageType::Invalid => false,
+///     MessageType::Error => true,
+///     MessageType::Reply => true,
+///     MessageType::Signal => false,
 /// }));
 ///
 /// Ok(())

--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -13,6 +13,7 @@ use std::os::unix::io::RawFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 
+use nix::cmsg_space;
 use nix::sys::socket::recvmsg;
 use nix::sys::socket::sendmsg;
 use nix::sys::socket::ControlMessage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@
 //! in the src/bin directory but the gist is:
 //!
 //! ```rust,no_run
-//! use rustbus::{message::{Container, DictMap}, message_builder::MessageBuilder, standard_messages};
+//! use rustbus::{get_session_bus_path, standard_messages, Conn, Container, DictMap, MessageBuilder};
 //!
 //! fn main() -> Result<(), rustbus::client_conn::Error> {
 //!     // Connect to the session bus
-//!     let session_path = rustbus::client_conn::get_session_bus_path()?;
-//!     let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
+//!     let session_path = get_session_bus_path()?;
+//!     let con = Conn::connect_to_bus(session_path, true)?;
 //!
 //!     // Wrap the con in an RpcConnection which provides many convenient functions
 //!     let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
@@ -53,3 +53,7 @@ pub mod message_builder;
 pub mod signature;
 pub mod standard_messages;
 pub mod unmarshal;
+
+pub use client_conn::{get_session_bus_path, get_system_bus_path, Conn, RpcConn};
+pub use message::{Container, DictMap, Message, MessageType};
+pub use message_builder::{CallBuilder, MessageBuilder, SignalBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,42 +5,44 @@
 //! ```rust,no_run
 //! use rustbus::{message::{Container, DictMap}, message_builder::MessageBuilder, standard_messages};
 //!
-//! // Connect to the session bus
-//! let session_path = rustbus::client_conn::get_session_bus_path().unwrap();
-//! let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true).unwrap();
+//! fn main() -> Result<(), rustbus::client_conn::Error> {
+//!     // Connect to the session bus
+//!     let session_path = rustbus::client_conn::get_session_bus_path()?;
+//!     let con = rustbus::client_conn::Conn::connect_to_bus(session_path, true)?;
 //!
-//! // Wrap the con in an RpcConnection which provides many convenient functions
-//! let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
+//!     // Wrap the con in an RpcConnection which provides many convenient functions
+//!     let mut rpc_con = rustbus::client_conn::RpcConn::new(con);
 //!
-//! // send the obligatory hello message
-//! rpc_con.send_message(standard_messages::hello()).unwrap();
+//!     // send the obligatory hello message
+//!     rpc_con.send_message(standard_messages::hello())?;
 //!
-//! // Request a bus name if you want to
-//! rpc_con.send_message(standard_messages::request_name(
-//!     "io.killing.spark".into(),
-//!     0,
-//! ))
-//! .unwrap();
+//!     // Request a bus name if you want to
+//!     rpc_con.send_message(standard_messages::request_name(
+//!         "io.killing.spark".into(),
+//!         0,
+//!     ))?;
 //!
-//! // send a signal to all bus members
-//! let sig = MessageBuilder::new()
-//! .signal(
-//!     "io.killing.spark".into(),
-//!     "TestSignal".into(),
-//!     "/io/killing/spark".into(),
-//! )
-//! .with_params(vec![
-//!     Container::Array(vec!["ABCDE".to_owned().into()]).into(),
-//!     Container::Struct(vec![162254319i32.into(), "AABB".to_owned().into()]).into(),
-//!     Container::Array(vec![
+//!     // send a signal to all bus members
+//!     let sig = MessageBuilder::new()
+//!     .signal(
+//!         "io.killing.spark".into(),
+//!         "TestSignal".into(),
+//!         "/io/killing/spark".into(),
+//!     )
+//!     .with_params(vec![
+//!         Container::Array(vec!["ABCDE".to_owned().into()]).into(),
 //!         Container::Struct(vec![162254319i32.into(), "AABB".to_owned().into()]).into(),
-//!         Container::Struct(vec![305419896i32.into(), "CCDD".to_owned().into()]).into(),
+//!         Container::Array(vec![
+//!             Container::Struct(vec![162254319i32.into(), "AABB".to_owned().into()]).into(),
+//!             Container::Struct(vec![305419896i32.into(), "CCDD".to_owned().into()]).into(),
+//!         ])
+//!         .into(),
+//!         Container::Dict(DictMap::new()).into(),
 //!     ])
-//!     .into(),
-//!     Container::Dict(DictMap::new()).into(),
-//! ])
-//! .build();
-//! rpc_con.send_message(sig).unwrap();
+//!     .build();
+//!     rpc_con.send_message(sig)?;
+//!     Ok(())
+//! }
 //! ```
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,6 @@
 //! }
 //! ```
 
-#[macro_use]
-extern crate nix;
-
 pub mod auth;
 pub mod client_conn;
 pub mod marshal;

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -147,7 +147,7 @@ fn marshal_header(
     if !msg.params.is_empty() {
         let mut sig_str = String::new();
         for param in &msg.params {
-            param.make_signature(&mut sig_str);
+            param.make_signature(&mut sig_str)?;
         }
         marshal_header_field(byteorder, &message::HeaderField::Signature(sig_str), buf)?;
     }


### PR DESCRIPTION
I started removing unwraps. 
Also removed the extern crate mentions, it's no longer necessary since rust 2018 except I think sometimes in `build.rs` files.
And exposed the most important types (the ones used in the examples) so one can, but does not have to, explicitly specify the modules.