### PR TITLE
Add missing Boolean signature to parser

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -41,6 +41,7 @@ enum Token {
     Structstart,
     Structend,
     Array,
+    Boolean,
     Byte,
     Int16,
     Uint16,
@@ -65,6 +66,7 @@ fn make_tokens(sig: &str) -> Result<Vec<Token>> {
             '(' => Token::Structstart,
             ')' => Token::Structend,
             'a' => Token::Array,
+            'b' => Token::Boolean,
             'y' => Token::Byte,
             'n' => Token::Int16,
             'q' => Token::Uint16,
@@ -180,6 +182,10 @@ impl Type {
             Token::Byte => {
                 tokens.remove(0);
                 Ok(Type::Base(Base::Byte))
+            }
+            Token::Boolean => {
+                tokens.remove(0);
+                Ok(Type::Base(Base::Boolean))
             }
             Token::Int16 => {
                 tokens.remove(0);


### PR DESCRIPTION
I was wondering whether rustbus didn't handle Boolean type.
e.g. 
`$ dbus-send --type=method_call --dest=my.test.iface / my.test.iface boolean:true
`
gave to me UnmarshalError(InvalidSignature)
This pr just adds Boolean type to parser