### PR TITLE
Null-terminate signature string when marshalling variants

### DIFF
--- a/src/wire/marshal_base.rs
+++ b/src/wire/marshal_base.rs
@@ -65,7 +65,7 @@ fn marshal_objectpath(
     write_string(&s, byteorder, buf);
     Ok(())
 }
-fn marshal_signature(s: &str, buf: &mut Vec<u8>) -> message::Result<()> {
+pub(super) fn marshal_signature(s: &str, buf: &mut Vec<u8>) -> message::Result<()> {
     params::validate_signature(&s)?;
     write_signature(&s, buf);
     Ok(())

--- a/src/wire/marshal_container.rs
+++ b/src/wire/marshal_container.rs
@@ -59,9 +59,7 @@ fn marshal_variant(
 ) -> message::Result<()> {
     let mut sig_str = String::new();
     var.sig.to_str(&mut sig_str);
-    buf.push(sig_str.len() as u8);
-    buf.extend(sig_str.bytes());
-    buf.push(0);
+    marshal_signature(&sig_str, buf)?;
     marshal_param(&var.value, byteorder, buf)?;
     Ok(())
 }

--- a/src/wire/marshal_container.rs
+++ b/src/wire/marshal_container.rs
@@ -61,6 +61,7 @@ fn marshal_variant(
     var.sig.to_str(&mut sig_str);
     buf.push(sig_str.len() as u8);
     buf.extend(sig_str.bytes());
+    buf.push(0);
     marshal_param(&var.value, byteorder, buf)?;
     Ok(())
 }


### PR DESCRIPTION
Before this change, DBus would reject some variant containing messages produced by this library if the null-byte cause things to be shifted when marshalling downstream types.