### PR TITLE
Check for null bytes within String when marshalling

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -188,6 +188,7 @@ pub enum Error {
     DictValueTypesDiffer,
     EmptyArray,
     EmptyDict,
+    StringContainsNullByte,
 }
 
 /// The supported byte orders

--- a/src/wire/marshal_base.rs
+++ b/src/wire/marshal_base.rs
@@ -53,8 +53,12 @@ fn marshal_string(
     byteorder: message::ByteOrder,
     buf: &mut Vec<u8>,
 ) -> message::Result<()> {
-    write_string(&s, byteorder, buf);
-    Ok(())
+    if s.contains('\0') {
+        Err(message::Error::StringContainsNullByte)
+    } else {
+        write_string(&s, byteorder, buf);
+        Ok(())
+    }
 }
 fn marshal_objectpath(
     s: &str,


### PR DESCRIPTION
Rust's `String` is allowed to contain any valid UTF-8 including U+0000 (null byte). The DBus spec doesn't allow for U+0000.