### PR TITLE
Add get2(), get3(), ... as helper functions to MessageBodyParser

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -57,6 +57,27 @@ impl DynamicHeader {
         }
         err_resp
     }
+    /// Make a correctly addressed response with the correct response serial
+    pub fn make_response(&self) -> crate::message_builder::MarshalledMessage {
+        crate::message_builder::MarshalledMessage {
+            typ: MessageType::Reply,
+            dynheader: DynamicHeader {
+                interface: None,
+                member: None,
+                object: None,
+                destination: self.sender.clone(),
+                serial: None,
+                num_fds: None,
+                sender: None,
+                signature: None,
+                response_serial: self.serial,
+                error_name: None,
+            },
+            raw_fds: Vec::new(),
+            flags: 0,
+            body: crate::message_builder::MarshalledMessageBody::new(),
+        }
+    }
 }
 
 /// A message with all the different fields it may or may not have
@@ -114,25 +135,12 @@ impl<'a, 'e> Message<'a, 'e> {
     }
 
     /// Make a correctly addressed response with the correct response serial
+    /// This is identical to calling [`self.dynheader.make_response()`].
+    ///
+    /// [`self.dynheader.make_response()`]: ./struct.DynamicHeader.html#method.make_response
+    #[inline]
     pub fn make_response(&self) -> crate::message_builder::MarshalledMessage {
-        crate::message_builder::MarshalledMessage {
-            typ: MessageType::Reply,
-            dynheader: DynamicHeader {
-                interface: None,
-                member: None,
-                object: None,
-                destination: self.dynheader.sender.clone(),
-                serial: None,
-                num_fds: None,
-                sender: None,
-                signature: None,
-                response_serial: self.dynheader.serial,
-                error_name: None,
-            },
-            raw_fds: Vec::new(),
-            flags: 0,
-            body: crate::message_builder::MarshalledMessageBody::new(),
-        }
+        self.dynheader.make_response()
     }
 
     pub fn set_flag(&mut self, flag: HeaderFlags) {

--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -428,34 +428,34 @@ fn test_marshal_trait() {
     type WrongNestedDict =
         std::collections::HashMap<String, std::collections::HashMap<String, u64>>;
     assert_eq!(
-        body_iter.get::<WrongNestedDict>().unwrap().err().unwrap(),
+        body_iter.get::<WrongNestedDict>().err().unwrap(),
         crate::wire::unmarshal::Error::WrongSignature
     );
     type WrongStruct = (u64, i32, String);
     assert_eq!(
-        body_iter.get::<WrongStruct>().unwrap().err().unwrap(),
+        body_iter.get::<WrongStruct>().err().unwrap(),
         crate::wire::unmarshal::Error::WrongSignature
     );
 
     // the get the correct type and make sure the content is correct
     type NestedDict = std::collections::HashMap<String, std::collections::HashMap<String, u32>>;
-    let newmap2: NestedDict = body_iter.get().unwrap().unwrap();
+    let newmap2: NestedDict = body_iter.get().unwrap();
     assert_eq!(newmap2.len(), 1);
     assert_eq!(newmap2.get("a").unwrap().len(), 1);
     assert_eq!(*newmap2.get("a").unwrap().get("a").unwrap(), 4);
 
     // again try some stuff that has the wrong signature
     assert_eq!(
-        body_iter.get::<WrongNestedDict>().unwrap().err().unwrap(),
+        body_iter.get::<WrongNestedDict>().err().unwrap(),
         crate::wire::unmarshal::Error::WrongSignature
     );
     assert_eq!(
-        body_iter.get::<WrongStruct>().unwrap().err().unwrap(),
+        body_iter.get::<WrongStruct>().err().unwrap(),
         crate::wire::unmarshal::Error::WrongSignature
     );
 
     // get the empty map next
-    let newemptymap: std::collections::HashMap<&str, u32> = body_iter.get().unwrap().unwrap();
+    let newemptymap: std::collections::HashMap<&str, u32> = body_iter.get().unwrap();
     assert_eq!(newemptymap.len(), 0);
 }
 

--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -323,8 +323,8 @@ impl MarshalledMessageBody {
 
     /// Create a parser to retrieve parameters from the body.
     #[inline]
-    pub fn parser(&self) -> MessageBodyIter {
-        MessageBodyIter::new(&self)
+    pub fn parser(&self) -> MessageBodyParser {
+        MessageBodyParser::new(&self)
     }
 }
 
@@ -422,7 +422,7 @@ fn test_marshal_trait() {
     );
 
     // try to unmarshal stuff
-    let mut body_iter = MessageBodyIter::new(&body);
+    let mut body_iter = MessageBodyParser::new(&body);
 
     // first try some stuff that has the wrong signature
     type WrongNestedDict =
@@ -484,14 +484,14 @@ use crate::wire::unmarshal_trait::Unmarshal;
 /// that you can use to get the params one by one, calling `get::<T>` until you have obtained all the parameters.
 /// If you try to get more parameters than the signature has types, it will return None, if you try to get a parameter that doesn not
 /// fit the current one, it will return an Error::WrongSignature, but you can safely try other types, the iterator stays valid.
-pub struct MessageBodyIter<'body> {
+pub struct MessageBodyParser<'body> {
     buf_idx: usize,
     sig_idx: usize,
     sigs: Vec<crate::signature::Type>,
     body: &'body MarshalledMessageBody,
 }
 
-impl<'ret, 'body: 'ret> MessageBodyIter<'body> {
+impl<'ret, 'body: 'ret> MessageBodyParser<'body> {
     pub fn new(body: &'body MarshalledMessageBody) -> Self {
         Self {
             buf_idx: 0,

--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -457,6 +457,23 @@ fn test_marshal_trait() {
     // get the empty map next
     let newemptymap: std::collections::HashMap<&str, u32> = body_iter.get().unwrap();
     assert_eq!(newemptymap.len(), 0);
+
+    // test get2()
+    let mut body_iter = body.parser();
+    assert_eq!(
+        body_iter.get2::<NestedDict, u16>().unwrap_err(),
+        crate::wire::unmarshal::Error::WrongSignature
+    );
+
+    // test to make sure body_iter is left unchanged from last failure and the map is
+    // pulled out identically from above
+    let (newmap2, newemptymap): (NestedDict, std::collections::HashMap<&str, u32>) =
+        body_iter.get2().unwrap();
+    // repeat assertions from above
+    assert_eq!(newmap2.len(), 1);
+    assert_eq!(newmap2.get("a").unwrap().len(), 1);
+    assert_eq!(*newmap2.get("a").unwrap().get("a").unwrap(), 4);
+    assert_eq!(newemptymap.len(), 0);
 }
 
 use crate::wire::unmarshal_trait::Unmarshal;

--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -464,6 +464,12 @@ fn test_marshal_trait() {
         body_iter.get2::<NestedDict, u16>().unwrap_err(),
         crate::wire::unmarshal::Error::WrongSignature
     );
+    assert_eq!(
+        body_iter
+            .get3::<NestedDict, std::collections::HashMap<&str, u32>, u32>()
+            .unwrap_err(),
+        crate::wire::unmarshal::Error::EndOfMessage
+    );
 
     // test to make sure body_iter is left unchanged from last failure and the map is
     // pulled out identically from above
@@ -474,6 +480,10 @@ fn test_marshal_trait() {
     assert_eq!(newmap2.get("a").unwrap().len(), 1);
     assert_eq!(*newmap2.get("a").unwrap().get("a").unwrap(), 4);
     assert_eq!(newemptymap.len(), 0);
+    assert_eq!(
+        body_iter.get::<u16>().unwrap_err(),
+        crate::wire::unmarshal::Error::EndOfMessage
+    );
 }
 
 use crate::wire::unmarshal_trait::Unmarshal;

--- a/src/wire/unmarshal.rs
+++ b/src/wire/unmarshal.rs
@@ -35,6 +35,14 @@ pub enum Error {
     EndOfMessage,
 }
 
+impl Error {
+    /// Checks if `self` is an `EndOfMessage` error.
+    #[inline]
+    pub fn is_end_of_message(&self) -> bool {
+        self == &Error::EndOfMessage
+    }
+}
+
 pub const HEADER_LEN: usize = 12;
 
 pub type UnmarshalResult<T> = std::result::Result<(usize, T), Error>;

--- a/src/wire/unmarshal.rs
+++ b/src/wire/unmarshal.rs
@@ -32,6 +32,7 @@ pub enum Error {
     UnknownHeaderField,
     PaddingContainedData,
     InvalidBoolean,
+    EndOfMessage,
 }
 
 pub const HEADER_LEN: usize = 12;


### PR DESCRIPTION
One of things I've found to be missing when working with the new `MarshalledMessage` struct is a better way to get parameters out of received messages.

Generally I find that when receiving messages on DBus, you know the exact types that you expect to receive. This lends itself to  a convenient pattern that I hope to introduce
```rust
// if you expect a message to containt 2 params of type String and bool
let (p1, p2): (String, bool) = marshalled_msg1.unmarshal_params2()?;
// if you expect a message to contain 3 params of type u8, u16, u32
let (p1, p2, p3) : (u8, u16, u32) = marshalled_msg2.unmarshal_params3()?;
```

I haven't tested or debugged this at all yet, because I want to see if this would be a good addition first.