### PR TITLE
No longer panic in MessageBodyParser::new() on empty sig

### DIFF
--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -648,10 +648,17 @@ pub struct MessageBodyParser<'body> {
 
 impl<'ret, 'body: 'ret> MessageBodyParser<'body> {
     pub fn new(body: &'body MarshalledMessageBody) -> Self {
+        let sigs = match crate::signature::Type::parse_description(&body.sig) {
+            Ok(sigs) => sigs,
+            Err(e) => match e {
+                crate::signature::Error::EmptySignature => Vec::new(),
+                _ => panic!("MarshalledMessageBody has bad signature: {:?}", e),
+            },
+        };
         Self {
             buf_idx: 0,
             sig_idx: 0,
-            sigs: crate::signature::Type::parse_description(&body.sig).unwrap(),
+            sigs,
             body,
         }
     }


### PR DESCRIPTION
An empty body is still a valid body so I think there shouldn't be a panic when creating a `MessageBodyParser` from an empty body. If a body is unexpectedly empty, the users of the crate can handle that error when using the get functions.
