### PR TITLE
Add Variant struct to unmarshal variants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use wire::unmarshal::traits::Unmarshal;
 mod tests;
 
 /// The supported byte orders
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ByteOrder {
     LittleEndian,
     BigEndian,

--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -639,6 +639,7 @@ use crate::wire::unmarshal::traits::Unmarshal;
 /// that you can use to get the params one by one, calling `get::<T>` until you have obtained all the parameters.
 /// If you try to get more parameters than the signature has types, it will return None, if you try to get a parameter that doesn not
 /// fit the current one, it will return an Error::WrongSignature, but you can safely try other types, the iterator stays valid.
+#[derive(Debug)]
 pub struct MessageBodyParser<'body> {
     buf_idx: usize,
     sig_idx: usize,

--- a/src/params/validation.rs
+++ b/src/params/validation.rs
@@ -21,6 +21,7 @@ pub enum Error {
     ArrayElementTypesDiffer,
     DictKeyTypesDiffer,
     DictValueTypesDiffer,
+	ByteOrderMismatch
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/src/params/validation.rs
+++ b/src/params/validation.rs
@@ -21,7 +21,7 @@ pub enum Error {
     ArrayElementTypesDiffer,
     DictKeyTypesDiffer,
     DictValueTypesDiffer,
-	ByteOrderMismatch
+    ByteOrderMismatch,
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/src/params/validation.rs
+++ b/src/params/validation.rs
@@ -21,7 +21,6 @@ pub enum Error {
     ArrayElementTypesDiffer,
     DictKeyTypesDiffer,
     DictValueTypesDiffer,
-    ByteOrderMismatch,
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/src/wire/marshal/traits.rs
+++ b/src/wire/marshal/traits.rs
@@ -621,7 +621,7 @@ impl Marshal for ObjectPath<'_> {
         self.0.marshal(byteorder, buf)
     }
 }
-
+#[derive(Debug, PartialEq)]
 pub struct SignatureWrapper<'a>(&'a str);
 impl<'a> SignatureWrapper<'a> {
     pub fn new(sig: &'a str) -> Result<Self, crate::params::validation::Error> {
@@ -648,6 +648,7 @@ impl Marshal for SignatureWrapper<'_> {
         Ok(())
     }
 }
+#[derive(Debug, PartialEq)]
 pub struct UnixFd(pub u32);
 impl Signature for UnixFd {
     fn signature() -> crate::signature::Type {

--- a/src/wire/marshal/traits.rs
+++ b/src/wire/marshal/traits.rs
@@ -662,24 +662,6 @@ impl Marshal for UnixFd {
         self.0.marshal(byteorder, buf)
     }
 }
-
-impl Marshal for crate::wire::unmarshal::traits::Variant<'_> {
-    fn marshal(&self, byteorder: ByteOrder, buf: &mut Vec<u8>) -> Result<(), crate::Error> {
-        if byteorder != self.byteorder {
-            return Err(crate::Error::Validation(
-                params::validation::Error::ByteOrderMismatch,
-            ));
-        }
-        let mut sig_str = String::new();
-        self.sig.to_str(&mut sig_str);
-        debug_assert!(sig_str.len() <= 255);
-        buf.push(sig_str.len() as u8);
-        buf.extend_from_slice(sig_str.as_bytes());
-        crate::wire::util::pad_to_align(self.sig.get_alignment(), buf);
-        buf.extend_from_slice(&self.buf[self.offset..]);
-        Ok(())
-    }
-}
 #[test]
 fn test_trait_signature_creation() {
     let mut msg = crate::message_builder::MarshalledMessage::new();

--- a/src/wire/marshal/traits.rs
+++ b/src/wire/marshal/traits.rs
@@ -665,9 +665,11 @@ impl Marshal for UnixFd {
 
 impl Marshal for crate::wire::unmarshal::traits::Variant<'_> {
     fn marshal(&self, byteorder: ByteOrder, buf: &mut Vec<u8>) -> Result<(), crate::Error> {
-		if byteorder != self.byteorder {
-			return Err(crate::Error::Validation(params::validation::Error::ByteOrderMismatch));
-		}
+        if byteorder != self.byteorder {
+            return Err(crate::Error::Validation(
+                params::validation::Error::ByteOrderMismatch,
+            ));
+        }
         let mut sig_str = String::new();
         self.sig.to_str(&mut sig_str);
         debug_assert!(sig_str.len() <= 255);

--- a/src/wire/unmarshal/traits.rs
+++ b/src/wire/unmarshal/traits.rs
@@ -570,6 +570,69 @@ impl<'r, 'buf: 'r> Unmarshal<'r, 'buf> for crate::wire::marshal::traits::ObjectP
     }
 }
 
+pub struct Variant<'buf> {
+    pub(crate) sig: signature::Type,
+    pub(crate) byteorder: ByteOrder,
+    pub(crate) offset: usize,
+    pub(crate) buf: &'buf [u8],
+}
+impl<'r, 'buf: 'r> Variant<'buf> {
+    /// Get the [`Type`] of the value contained by the variant.
+    ///
+    /// [`Type`]: /rustbus/signature/enum.Type.html
+    pub fn get_value_sig(&self) -> &signature::Type {
+        &self.sig
+    }
+
+    /// Unmarshal the variant's value. This method is used in the same way as [`MessageBodyParser::get()`].
+    ///
+    /// [`MessageBodyParser::get()`]: /rustbus/message_builder/struct.MessageBodyParser.html#method.get
+    pub fn get<T: Unmarshal<'r, 'buf>>(&self) -> Result<T, unmarshal::Error> {
+        if self.sig != T::signature() {
+            return Err(unmarshal::Error::WrongSignature);
+        }
+        T::unmarshal(self.byteorder, self.buf, self.offset).map(|r| r.1)
+    }
+}
+impl Signature for Variant<'_> {
+    fn signature() -> signature::Type {
+        signature::Type::Container(signature::Container::Variant)
+    }
+    fn alignment() -> usize {
+        Variant::signature().get_alignment()
+    }
+}
+impl<'r, 'buf: 'r> Unmarshal<'r, 'buf> for Variant<'buf> {
+    fn unmarshal(
+        byteorder: ByteOrder,
+        buf: &'buf [u8],
+        offset: usize,
+    ) -> unmarshal::UnmarshalResult<Self> {
+        // let padding = rustbus::wire::util::align_offset(Self::get_alignment());
+        let (mut used, desc) = util::unmarshal_signature(&buf[offset..])?;
+        let mut sigs = match signature::Type::parse_description(desc) {
+            Ok(sigs) => sigs,
+            Err(_) => return Err(unmarshal::Error::WrongSignature),
+        };
+        if sigs.len() != 1 {
+            return Err(unmarshal::Error::WrongSignature);
+        }
+        let sig = sigs.remove(0);
+        used += util::align_offset(sig.get_alignment(), buf, offset + used)?;
+        let start_loc = offset + used;
+        used += crate::wire::validate_raw::validate_marshalled(byteorder, start_loc, buf, &sig)
+            .map_err(|e| e.1)?;
+        Ok((
+            used,
+            Variant {
+                sig,
+                buf: &buf[..offset + used],
+                offset: start_loc,
+                byteorder,
+            },
+        ))
+    }
+}
 #[test]
 fn test_unmarshal_traits() {
     use crate::Marshal;
@@ -632,59 +695,142 @@ fn test_unmarshal_traits() {
     assert_eq!(fd.0, 10);
 }
 
-pub struct Variant<'buf> {
-    pub(crate) sig: signature::Type,
-    pub(crate) byteorder: ByteOrder,
-    pub(crate) offset: usize,
-    pub(crate) buf: &'buf [u8],
-}
-impl<'r, 'buf: 'r> Variant<'buf> {
-    pub fn get_value_sig(&self) -> &signature::Type {
-        &self.sig
+#[test]
+fn test_variant() {
+    use crate::message_builder::MarshalledMessageBody;
+    use crate::params::{Array, Base, Container, Dict, Param, Variant as ParamVariant};
+    use crate::signature::Type;
+    use crate::wire::marshal::traits::{SignatureWrapper, UnixFd};
+    use std::collections::HashMap;
+
+    // inital test data
+    let params: [(Param, Type); 11] = [
+        (Base::Byte(0x41).into(), u8::signature()),
+        (Base::Int16(-1234).into(), i16::signature()),
+        (Base::Uint16(1234).into(), u16::signature()),
+        (Base::Int32(-1234567).into(), i32::signature()),
+        (Base::Uint32(1234567).into(), u32::signature()),
+        (Base::UnixFd(1).into(), UnixFd::signature()),
+        (Base::Int64(-1234568901234).into(), i64::signature()),
+        (Base::Uint64(1234568901234).into(), u64::signature()),
+        (
+            Base::String("Hello world!".to_string()).into(),
+            String::signature(),
+        ),
+        (
+            Base::Signature("sy".to_string()).into(),
+            SignatureWrapper::signature(),
+        ),
+        (Base::Boolean(true).into(), bool::signature()),
+    ];
+
+    // push initial data as individual variants
+    let mut body = MarshalledMessageBody::new();
+    for param in &params {
+        let cont = Container::Variant(Box::new(ParamVariant {
+            sig: param.1.clone(),
+            value: param.0.clone(),
+        }));
+        body.push_old_param(&Param::Container(cont)).unwrap();
     }
-    pub fn get<T: Unmarshal<'r, 'buf>>(&self) -> Result<T, unmarshal::Error> {
-        if self.sig != T::signature() {
-            return Err(unmarshal::Error::WrongSignature);
-        }
-        T::unmarshal(self.byteorder, self.buf, self.offset).map(|r| r.1)
-    }
-}
-impl Signature for Variant<'_> {
-    fn signature() -> signature::Type {
-        signature::Type::Container(signature::Container::Variant)
-    }
-    fn alignment() -> usize {
-        Variant::signature().get_alignment()
-    }
-}
-impl<'r, 'buf: 'r> Unmarshal<'r, 'buf> for Variant<'buf> {
-    fn unmarshal(
-        byteorder: ByteOrder,
-        buf: &'buf [u8],
-        offset: usize,
-    ) -> unmarshal::UnmarshalResult<Self> {
-        // let padding = rustbus::wire::util::align_offset(Self::get_alignment());
-        let (mut used, desc) = util::unmarshal_signature(&buf[offset..])?;
-        let mut sigs = match signature::Type::parse_description(desc) {
-            Ok(sigs) => sigs,
-            Err(_) => return Err(unmarshal::Error::WrongSignature),
-        };
-        if sigs.len() != 1 {
-            return Err(unmarshal::Error::WrongSignature);
-        }
-        let sig = sigs.remove(0);
-        used += util::align_offset(sig.get_alignment(), buf, offset + used)?;
-        let start_loc = offset + used;
-        used += crate::wire::validate_raw::validate_marshalled(byteorder, start_loc, buf, &sig)
-            .map_err(|e| e.1)?;
-        Ok((
-            used,
-            Variant {
-                sig,
-                buf: &buf[..offset + used],
-                offset: start_loc,
-                byteorder,
-            },
-        ))
-    }
+
+    // push initial data as Array of variants
+    let var_vec = params
+        .iter()
+        .map(|(param, typ)| {
+            Param::Container(Container::Variant(Box::new(ParamVariant {
+                sig: typ.clone(),
+                value: param.clone(),
+            })))
+        })
+        .collect();
+    let vec_param = Param::Container(Container::Array(Array {
+        element_sig: Variant::signature(),
+        values: var_vec,
+    }));
+    body.push_old_param(&vec_param).unwrap();
+
+    // push initial data as Dict of {String,variants}
+    let var_map = params
+        .iter()
+        .enumerate()
+        .map(|(i, (param, typ))| {
+            (
+                Base::String(format!("{}", i)),
+                Param::Container(Container::Variant(Box::new(ParamVariant {
+                    sig: typ.clone(),
+                    value: param.clone(),
+                }))),
+            )
+        })
+        .collect();
+    let map_param = Param::Container(Container::Dict(Dict {
+        key_sig: crate::signature::Base::String,
+        value_sig: Variant::signature(),
+        map: var_map,
+    }));
+    body.push_old_param(&map_param).unwrap();
+
+    // check the individual variants
+    let mut parser = body.parser();
+    assert_eq!(0x41_u8, parser.get::<Variant>().unwrap().get().unwrap());
+    assert_eq!(-1234_i16, parser.get::<Variant>().unwrap().get().unwrap());
+    assert_eq!(1234_u16, parser.get::<Variant>().unwrap().get().unwrap());
+    assert_eq!(
+        -1234567_i32,
+        parser.get::<Variant>().unwrap().get().unwrap()
+    );
+    assert_eq!(1234567_u32, parser.get::<Variant>().unwrap().get().unwrap());
+    assert_eq!(UnixFd(1), parser.get::<Variant>().unwrap().get().unwrap());
+    assert_eq!(
+        -1234568901234_i64,
+        parser.get::<Variant>().unwrap().get().unwrap()
+    );
+    assert_eq!(
+        1234568901234_u64,
+        parser.get::<Variant>().unwrap().get().unwrap()
+    );
+    assert_eq!(
+        "Hello world!",
+        parser.get::<Variant>().unwrap().get::<&str>().unwrap()
+    );
+    assert_eq!(
+        SignatureWrapper::new("sy").unwrap(),
+        parser.get::<Variant>().unwrap().get().unwrap()
+    );
+    assert_eq!(true, parser.get::<Variant>().unwrap().get().unwrap());
+
+    // check Array of variants
+    let var_vec: Vec<Variant> = parser.get().unwrap();
+    assert_eq!(0x41_u8, var_vec[0].get().unwrap());
+    assert_eq!(-1234_i16, var_vec[1].get().unwrap());
+    assert_eq!(1234_u16, var_vec[2].get().unwrap());
+    assert_eq!(-1234567_i32, var_vec[3].get().unwrap());
+    assert_eq!(1234567_u32, var_vec[4].get().unwrap());
+    assert_eq!(UnixFd(1), var_vec[5].get().unwrap());
+    assert_eq!(-1234568901234_i64, var_vec[6].get().unwrap());
+    assert_eq!(1234568901234_u64, var_vec[7].get().unwrap());
+    assert_eq!("Hello world!", var_vec[8].get::<&str>().unwrap());
+    assert_eq!(
+        SignatureWrapper::new("sy").unwrap(),
+        var_vec[9].get().unwrap()
+    );
+    assert_eq!(true, var_vec[10].get().unwrap());
+
+    // check Dict of {String, variants}
+    let var_map: HashMap<String, Variant> = parser.get().unwrap();
+    assert_eq!(0x41_u8, var_map["0"].get().unwrap());
+    assert_eq!(-1234_i16, var_map["1"].get().unwrap());
+    assert_eq!(1234_u16, var_map["2"].get().unwrap());
+    assert_eq!(-1234567_i32, var_map["3"].get().unwrap());
+    assert_eq!(1234567_u32, var_map["4"].get().unwrap());
+    assert_eq!(UnixFd(1), var_map["5"].get().unwrap());
+    assert_eq!(-1234568901234_i64, var_map["6"].get().unwrap());
+    assert_eq!(1234568901234_u64, var_map["7"].get().unwrap());
+    assert_eq!("Hello world!", var_map["8"].get::<&str>().unwrap());
+    assert_eq!(
+        SignatureWrapper::new("sy").unwrap(),
+        var_map["9"].get().unwrap()
+    );
+    assert_eq!(true, var_map["10"].get().unwrap());
 }

--- a/src/wire/unmarshal/traits.rs
+++ b/src/wire/unmarshal/traits.rs
@@ -642,9 +642,9 @@ impl<'r, 'buf: 'r> Variant<'buf> {
     pub fn get_value_sig(&self) -> &signature::Type {
         &self.sig
     }
-    pub fn get<T: Unmarshal<'r, 'buf>>(&self) -> Result<T, unmarshal::Error> {
-        if (self.sig != T::signature()) {
-            return Err(unmarshal::Error::WrongSignature);
+    pub fn get<T: Unmarshal<'r, 'buf>>(&self) -> Result<T, UnmarshalError> {
+        if self.sig != T::signature() {
+            return Err(UnmarshalError::WrongSignature);
         }
         T::unmarshal(self.byteorder, self.buf, self.offset).map(|r| r.1)
     }
@@ -664,23 +664,25 @@ impl<'r, 'buf: 'r> Unmarshal<'r, 'buf> for Variant<'buf> {
         offset: usize,
     ) -> unmarshal::UnmarshalResult<Self> {
         // let padding = rustbus::wire::util::align_offset(Self::get_alignment());
-        let (offset, desc) = crate::wire::util::unmarshal_signature(&buf[offset..])?;
+        let (mut used, desc) = rustbus::wire::util::unmarshal_signature(&buf[offset..])?;
+        let start_loc = offset + used;
         let mut sigs = match signature::Type::parse_description(desc) {
             Ok(sigs) => sigs,
-            Err(_) => return Err(unmarshal::Error::WrongSignature),
+            Err(_) => return Err(UnmarshalError::WrongSignature),
         };
         if sigs.len() != 1 {
-            return Err(unmarshal::Error::WrongSignature);
+            return Err(UnmarshalError::WrongSignature);
         }
         let sig = sigs.remove(0);
-        let end = crate::wire::validate_raw::validate_marshalled(byteorder, offset, buf, &sig)
-            .map_err(|e| e.1)?;
+        used +=
+            rustbus::wire::validate_raw::validate_marshalled(byteorder, offset + used, buf, &sig)
+                .map_err(|e| e.1)?;
         Ok((
-            end,
+            used,
             Variant {
                 sig,
-                buf: &buf[..end],
-                offset,
+                buf: &buf[..offset + used],
+                offset: start_loc,
                 byteorder,
             },
         ))

--- a/src/wire/validate_raw.rs
+++ b/src/wire/validate_raw.rs
@@ -116,7 +116,7 @@ pub fn validate_marshalled_base(
         }
         signature::Base::Signature => {
             // TODO validate
-            let (bytes, string) = crate::wire::util::unmarshal_signature(buf)
+            let (bytes, string) = crate::wire::util::unmarshal_signature(&buf[offset..])
                 .map_err(|err| (offset + padding, err))?;
             crate::params::validate_signature(string).map_err(|e| (offset, e.into()))?;
             Ok(bytes + padding)


### PR DESCRIPTION
This struct implements the `Unmarshal` trait, and act as intermediate that allows for the unmarshalling of variants. The struct has a `get()` method that similiar to `MessageBodyParser::get()` to retrieve the inner value.

Would there be any interest in adding something like this the crate? Currently there isn't a way to deconstruct a variant using the `Unmarshal` trait as far as I know, this is an attempt to remedy that, and this a solution from another crate I've been working on.
This PR still has some work to do. I haven't tested it beyond some simple examples, it still needs unit testing, and it needs documentation, but I would rather do after I know that this is worth inclusion.