### PR TITLE
Fix variant marshalling

### DIFF
--- a/src/message_builder.rs
+++ b/src/message_builder.rs
@@ -301,7 +301,6 @@ pub fn marshal_as_variant<P: Marshal>(
 ) -> Result<(), crate::Error> {
     let mut sig_str = String::new();
     P::signature().to_str(&mut sig_str);
-    crate::wire::util::pad_to_align(P::alignment(), buf);
     crate::wire::marshal::base::marshal_base_param(
         ByteOrder::LittleEndian,
         &crate::params::Base::Signature(sig_str),


### PR DESCRIPTION
Currently, padding is added when marshaling variants before pushing the signature string. This results in a bad alignment of the variant's signature. 

This pad_to_align can be can also be removed (rather than moved down) because it is duplicative. According to the [docs](https://docs.rs/rustbus/0.6.0/rustbus/wire/marshal/traits/trait.Marshal.html#implementing-for-your-own-structs) Marshal impls should do their own alignment:
>1. .... If your type is marshalled as a primitive type you still need to align to that types alignment.

