### PR TITLE
Add AsRawFd impl to Conn

### DIFF
--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -634,6 +634,8 @@ impl<'msga, 'msge> Conn {
 }
 
 impl AsRawFd for Conn {
+    /// Reading or writing to the `RawFd` may result in undefined behavior
+    /// and break the `Conn`.
     fn as_raw_fd(&self) -> RawFd {
         self.stream.as_raw_fd()
     }

--- a/src/client_conn.rs
+++ b/src/client_conn.rs
@@ -86,7 +86,9 @@ impl RpcConn {
             filter: Box::new(|_| true),
         }
     }
-
+    pub fn conn(&self) -> &Conn {
+        &self.conn
+    }
     pub fn conn_mut(&mut self) -> &mut Conn {
         &mut self.conn
     }
@@ -628,6 +630,12 @@ impl<'msga, 'msge> Conn {
         }
 
         Ok(serial)
+    }
+}
+
+impl AsRawFd for Conn {
+    fn as_raw_fd(&self) -> RawFd {
+        self.stream.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
Primarily intended to allow polling with other file descriptors. This can provide a massive performance benefit to applications that wish to maintain a low latency when responding to requests while also reducing system calls.

`RpcConn::conn` was added as an immutable complement to `RpcConn::conn_mut` to make `AsRawFd` more flexible.