### PR TITLE
Split conn

### DIFF
--- a/example_keywallet/src/bin/client/main.rs
+++ b/example_keywallet/src/bin/client/main.rs
@@ -3,17 +3,19 @@
 //! usecase to validate the existing codebase and new ideas
 
 use rustbus::connection::get_session_bus_path;
-use rustbus::connection::ll_conn::Conn;
+use rustbus::connection::ll_conn::DuplexConn;
 fn main() {
-    let mut con = Conn::connect_to_bus(get_session_bus_path().unwrap(), false).unwrap();
+    let mut con = DuplexConn::connect_to_bus(get_session_bus_path().unwrap(), false).unwrap();
 
-    con.send_message(
-        &mut rustbus::standard_messages::hello(),
-        rustbus::connection::Timeout::Infinite,
-    )
-    .unwrap();
+    con.send
+        .send_message(
+            &mut rustbus::standard_messages::hello(),
+            rustbus::connection::Timeout::Infinite,
+        )
+        .unwrap();
 
     let resp = con
+        .recv
         .get_next_message(rustbus::connection::Timeout::Infinite)
         .unwrap();
 

--- a/example_keywallet/src/bin/service/main.rs
+++ b/example_keywallet/src/bin/service/main.rs
@@ -199,19 +199,11 @@ fn session_handler(
 fn main() {
     let mut con = DuplexConn::connect_to_bus(get_session_bus_path().unwrap(), false).unwrap();
 
-    con.send
-        .send_message(
-            &mut rustbus::standard_messages::hello(),
-            rustbus::connection::Timeout::Infinite,
-        )
+    let unique_name = con
+        .send_hello(rustbus::connection::Timeout::Infinite)
         .unwrap();
 
-    let resp = con
-        .recv
-        .get_next_message(rustbus::connection::Timeout::Infinite)
-        .unwrap();
-
-    println!("Unique name: {}", resp.body.parser().get::<&str>().unwrap());
+    println!("Unique name: {}", unique_name);
 
     con.send
         .send_message(
@@ -223,6 +215,7 @@ fn main() {
         )
         .unwrap();
 
+    // The responses content should be looked at. ATM we just assume the name aquistion worked...
     let _resp = con
         .recv
         .get_next_message(rustbus::connection::Timeout::Infinite)

--- a/example_keywallet/src/bin/service/main.rs
+++ b/example_keywallet/src/bin/service/main.rs
@@ -6,7 +6,7 @@ use rustbus::connection::dispatch_conn::HandleEnvironment;
 use rustbus::connection::dispatch_conn::HandleResult;
 use rustbus::connection::dispatch_conn::Matches;
 use rustbus::connection::get_session_bus_path;
-use rustbus::connection::ll_conn::Conn;
+use rustbus::connection::ll_conn::DuplexConn;
 use rustbus::message_builder::MarshalledMessage;
 use rustbus::wire::marshal::traits::ObjectPath;
 
@@ -17,7 +17,7 @@ mod service_interface;
 pub struct Context {
     service: service::SecretService,
 }
-pub type MyHandleEnv<'a, 'b> = HandleEnvironment<'a, &'b mut Context, ()>;
+pub type MyHandleEnv<'a, 'b> = HandleEnvironment<&'b mut Context, ()>;
 
 fn default_handler(
     _ctx: &mut &mut Context,
@@ -197,30 +197,34 @@ fn session_handler(
 }
 
 fn main() {
-    let mut con = Conn::connect_to_bus(get_session_bus_path().unwrap(), false).unwrap();
+    let mut con = DuplexConn::connect_to_bus(get_session_bus_path().unwrap(), false).unwrap();
 
-    con.send_message(
-        &mut rustbus::standard_messages::hello(),
-        rustbus::connection::Timeout::Infinite,
-    )
-    .unwrap();
+    con.send
+        .send_message(
+            &mut rustbus::standard_messages::hello(),
+            rustbus::connection::Timeout::Infinite,
+        )
+        .unwrap();
 
     let resp = con
+        .recv
         .get_next_message(rustbus::connection::Timeout::Infinite)
         .unwrap();
 
     println!("Unique name: {}", resp.body.parser().get::<&str>().unwrap());
 
-    con.send_message(
-        &mut rustbus::standard_messages::request_name(
-            "io.killingspark.secrets".into(),
-            rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
-        ),
-        rustbus::connection::Timeout::Infinite,
-    )
-    .unwrap();
+    con.send
+        .send_message(
+            &mut rustbus::standard_messages::request_name(
+                "io.killingspark.secrets".into(),
+                rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
+            ),
+            rustbus::connection::Timeout::Infinite,
+        )
+        .unwrap();
 
     let _resp = con
+        .recv
         .get_next_message(rustbus::connection::Timeout::Infinite)
         .unwrap();
 

--- a/rustbus/benches/marshal_benchmark.rs
+++ b/rustbus/benches/marshal_benchmark.rs
@@ -8,7 +8,7 @@ use rustbus::wire::unmarshal::unmarshal_header;
 use rustbus::wire::unmarshal::unmarshal_next_message;
 
 fn marsh(msg: &rustbus::message_builder::MarshalledMessage, buf: &mut Vec<u8>) {
-    marshal(msg, rustbus::ByteOrder::LittleEndian, &[], buf).unwrap();
+    marshal(msg, rustbus::ByteOrder::LittleEndian, buf).unwrap();
 }
 
 fn unmarshal(buf: &[u8]) {

--- a/rustbus/examples/conn.rs
+++ b/rustbus/examples/conn.rs
@@ -1,10 +1,10 @@
 use rustbus::{
-    connection::Timeout, get_session_bus_path, standard_messages, Conn, MessageType, RpcConn,
+    connection::Timeout, get_session_bus_path, standard_messages, DuplexConn, MessageType, RpcConn,
 };
 
 fn main() -> Result<(), rustbus::connection::Error> {
     let session_path = get_session_bus_path()?;
-    let con = Conn::connect_to_bus(session_path, true)?;
+    let con = DuplexConn::connect_to_bus(session_path, true)?;
     let mut rpc_con = RpcConn::new(con);
 
     let mut hello_msg = standard_messages::hello();

--- a/rustbus/examples/conn.rs
+++ b/rustbus/examples/conn.rs
@@ -7,8 +7,6 @@ fn main() -> Result<(), rustbus::connection::Error> {
     let con = DuplexConn::connect_to_bus(session_path, true)?;
     let mut rpc_con = RpcConn::new(con);
 
-    let mut hello_msg = standard_messages::hello();
-
     rpc_con.set_filter(Box::new(|msg| match msg.typ {
         MessageType::Call => false,
         MessageType::Invalid => false,
@@ -21,7 +19,7 @@ fn main() -> Result<(), rustbus::connection::Error> {
     }));
 
     //println!("Send message: {:?}", hello_msg);
-    let hello_serial = rpc_con.send_message(&mut hello_msg, Timeout::Infinite)?;
+    let hello_serial = rpc_con.send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
 
     println!("\n");
     println!("\n");

--- a/rustbus/examples/dispatch.rs
+++ b/rustbus/examples/dispatch.rs
@@ -67,11 +67,7 @@ fn main() {
     let mut con =
         DuplexConn::connect_to_bus(rustbus::connection::get_session_bus_path().unwrap(), false)
             .unwrap();
-    con.send
-        .send_message(
-            &mut rustbus::standard_messages::hello(),
-            rustbus::connection::Timeout::Infinite,
-        )
+    con.send_hello(rustbus::connection::Timeout::Infinite)
         .unwrap();
 
     if std::env::args().find(|arg| "server".eq(arg)).is_some() {

--- a/rustbus/examples/dispatch.rs
+++ b/rustbus/examples/dispatch.rs
@@ -2,11 +2,11 @@ use rustbus::connection::dispatch_conn::DispatchConn;
 use rustbus::connection::dispatch_conn::HandleEnvironment;
 use rustbus::connection::dispatch_conn::HandleResult;
 use rustbus::connection::dispatch_conn::Matches;
-use rustbus::connection::ll_conn::Conn;
+use rustbus::connection::ll_conn::DuplexConn;
 use rustbus::message_builder::MarshalledMessage;
 
 // just to make the function definitions a bit shorter
-type MyHandleEnv<'a, 'b> = HandleEnvironment<'a, &'b mut Counter, ()>;
+type MyHandleEnv<'a, 'b> = HandleEnvironment<&'b mut Counter, ()>;
 
 struct Counter {
     count: u64,
@@ -65,22 +65,25 @@ fn name_handler(
 
 fn main() {
     let mut con =
-        Conn::connect_to_bus(rustbus::connection::get_session_bus_path().unwrap(), false).unwrap();
-    con.send_message(
-        &mut rustbus::standard_messages::hello(),
-        rustbus::connection::Timeout::Infinite,
-    )
-    .unwrap();
-
-    if std::env::args().find(|arg| "server".eq(arg)).is_some() {
-        con.send_message(
-            &mut rustbus::standard_messages::request_name(
-                "killing.spark.io".into(),
-                rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
-            ),
+        DuplexConn::connect_to_bus(rustbus::connection::get_session_bus_path().unwrap(), false)
+            .unwrap();
+    con.send
+        .send_message(
+            &mut rustbus::standard_messages::hello(),
             rustbus::connection::Timeout::Infinite,
         )
         .unwrap();
+
+    if std::env::args().find(|arg| "server".eq(arg)).is_some() {
+        con.send
+            .send_message(
+                &mut rustbus::standard_messages::request_name(
+                    "killing.spark.io".into(),
+                    rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
+                ),
+                rustbus::connection::Timeout::Infinite,
+            )
+            .unwrap();
 
         let mut counter = Counter { count: 0 };
         let dh = Box::new(default_handler);
@@ -109,7 +112,8 @@ fn main() {
             .at("killing.spark.io".into())
             .on("/ABCD".into())
             .build();
-        con.send_message(&mut msg1, rustbus::connection::Timeout::Infinite)
+        con.send
+            .send_message(&mut msg1, rustbus::connection::Timeout::Infinite)
             .unwrap();
 
         // pick up the name
@@ -118,7 +122,8 @@ fn main() {
             .at("killing.spark.io".into())
             .on("/A/B/moritz".into())
             .build();
-        con.send_message(&mut msg2, rustbus::connection::Timeout::Infinite)
+        con.send
+            .send_message(&mut msg2, rustbus::connection::Timeout::Infinite)
             .unwrap();
 
         // call new handler for that name
@@ -127,11 +132,14 @@ fn main() {
             .at("killing.spark.io".into())
             .on("/moritz".into())
             .build();
-        con.send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
+        con.send
+            .send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
             .unwrap();
-        con.send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
+        con.send
+            .send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
             .unwrap();
-        con.send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
+        con.send
+            .send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
             .unwrap();
     }
 }

--- a/rustbus/examples/sig.rs
+++ b/rustbus/examples/sig.rs
@@ -1,12 +1,9 @@
-use rustbus::{
-    connection::Timeout, get_session_bus_path, standard_messages, DuplexConn, MessageBuilder,
-};
+use rustbus::{connection::Timeout, get_session_bus_path, DuplexConn, MessageBuilder};
 
 fn main() -> Result<(), rustbus::connection::Error> {
     let session_path = get_session_bus_path()?;
     let mut con = DuplexConn::connect_to_bus(session_path, true)?;
-    con.send
-        .send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
+    con.send_hello(Timeout::Infinite)?;
 
     let mut sig = MessageBuilder::new()
         .signal(

--- a/rustbus/examples/sig.rs
+++ b/rustbus/examples/sig.rs
@@ -1,9 +1,12 @@
-use rustbus::{connection::Timeout, get_session_bus_path, standard_messages, Conn, MessageBuilder};
+use rustbus::{
+    connection::Timeout, get_session_bus_path, standard_messages, DuplexConn, MessageBuilder,
+};
 
 fn main() -> Result<(), rustbus::connection::Error> {
     let session_path = get_session_bus_path()?;
-    let mut con = Conn::connect_to_bus(session_path, true)?;
-    con.send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
+    let mut con = DuplexConn::connect_to_bus(session_path, true)?;
+    con.send
+        .send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
 
     let mut sig = MessageBuilder::new()
         .signal(
@@ -37,9 +40,9 @@ fn main() -> Result<(), rustbus::connection::Error> {
 
     println!("{:?}", sig);
 
-    con.send_message(&mut sig, Timeout::Infinite)?;
+    con.send.send_message(&mut sig, Timeout::Infinite)?;
     std::thread::sleep(std::time::Duration::from_secs(1));
-    con.send_message(&mut sig, Timeout::Infinite)?;
+    con.send.send_message(&mut sig, Timeout::Infinite)?;
 
     Ok(())
 }

--- a/rustbus/examples/user_defined_types.rs
+++ b/rustbus/examples/user_defined_types.rs
@@ -118,16 +118,13 @@ impl Marshal for &MyOtherSubType {
     }
 }
 
-use rustbus::{
-    connection::Timeout, get_session_bus_path, standard_messages, DuplexConn, MessageBuilder,
-};
+use rustbus::{connection::Timeout, get_session_bus_path, DuplexConn, MessageBuilder};
 
 // Just to have a main here we will send a message containing two MyType structs
 fn main() -> Result<(), rustbus::connection::Error> {
     let session_path = get_session_bus_path()?;
     let mut con = DuplexConn::connect_to_bus(session_path, true)?;
-    con.send
-        .send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
+    con.send_hello(Timeout::Infinite)?;
 
     let mut sig = MessageBuilder::new()
         .signal(

--- a/rustbus/examples/user_defined_types.rs
+++ b/rustbus/examples/user_defined_types.rs
@@ -118,13 +118,16 @@ impl Marshal for &MyOtherSubType {
     }
 }
 
-use rustbus::{connection::Timeout, get_session_bus_path, standard_messages, Conn, MessageBuilder};
+use rustbus::{
+    connection::Timeout, get_session_bus_path, standard_messages, DuplexConn, MessageBuilder,
+};
 
 // Just to have a main here we will send a message containing two MyType structs
 fn main() -> Result<(), rustbus::connection::Error> {
     let session_path = get_session_bus_path()?;
-    let mut con = Conn::connect_to_bus(session_path, true)?;
-    con.send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
+    let mut con = DuplexConn::connect_to_bus(session_path, true)?;
+    con.send
+        .send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
 
     let mut sig = MessageBuilder::new()
         .signal(
@@ -154,7 +157,7 @@ fn main() -> Result<(), rustbus::connection::Error> {
     sig.body.push_param(MyVar::Int32(100))?;
     sig.body.push_param(MyVar::Int64(-100))?;
 
-    con.send_message(&mut sig, Timeout::Infinite)?;
+    con.send.send_message(&mut sig, Timeout::Infinite)?;
 
     Ok(())
 }

--- a/rustbus/src/connection/ll_conn.rs
+++ b/rustbus/src/connection/ll_conn.rs
@@ -22,62 +22,29 @@ use nix::sys::uio::IoVec;
 
 /// A lowlevel abstraction over the raw unix socket
 #[derive(Debug)]
-pub struct Conn {
+pub struct SendConn {
     socket_addr: UnixAddr,
     stream: UnixStream,
 
     byteorder: ByteOrder,
-
-    msg_buf_in: Vec<u8>,
-    cmsgs_in: Vec<ControlMessageOwned>,
-
     msg_buf_out: Vec<u8>,
 
     serial_counter: u32,
 }
 
-impl<'msga, 'msge> Conn {
-    /// Connect to a unix socket and choose a byteorder
-    pub fn connect_to_bus_with_byteorder(
-        addr: UnixAddr,
-        byteorder: ByteOrder,
-        with_unix_fd: bool,
-    ) -> super::Result<Conn> {
-        let sock = socket(
-            socket::AddressFamily::Unix,
-            socket::SockType::Stream,
-            socket::SockFlag::empty(),
-            None,
-        )?;
-        let sock_addr = SockAddr::Unix(addr);
-        connect(sock, &sock_addr)?;
-        let mut stream = unsafe { UnixStream::from_raw_fd(sock) };
-        match auth::do_auth(&mut stream)? {
-            auth::AuthResult::Ok => {}
-            auth::AuthResult::Rejected => return Err(Error::AuthFailed),
-        }
+pub struct RecvConn {
+    stream: UnixStream,
 
-        if with_unix_fd {
-            match auth::negotiate_unix_fds(&mut stream)? {
-                auth::AuthResult::Ok => {}
-                auth::AuthResult::Rejected => return Err(Error::UnixFdNegotiationFailed),
-            }
-        }
+    msg_buf_in: Vec<u8>,
+    cmsgs_in: Vec<ControlMessageOwned>,
+}
 
-        auth::send_begin(&mut stream)?;
+pub struct DuplexConn {
+    pub send: SendConn,
+    pub recv: RecvConn,
+}
 
-        Ok(Conn {
-            socket_addr: addr,
-            stream,
-            msg_buf_in: Vec::new(),
-            cmsgs_in: Vec::new(),
-            msg_buf_out: Vec::new(),
-            byteorder,
-
-            serial_counter: 1,
-        })
-    }
-
+impl RecvConn {
     pub fn can_read_from_source(&self) -> nix::Result<bool> {
         let mut fdset = nix::sys::select::FdSet::new();
         let fd = self.stream.as_raw_fd();
@@ -88,11 +55,6 @@ impl<'msga, 'msge> Conn {
 
         nix::sys::select::select(None, Some(&mut fdset), None, None, Some(&mut zero_timeout))?;
         Ok(fdset.contains(fd))
-    }
-
-    /// Connect to a unix socket. The default little endian byteorder is used
-    pub fn connect_to_bus(addr: UnixAddr, with_unix_fd: bool) -> Result<Conn> {
-        Self::connect_to_bus_with_byteorder(addr, ByteOrder::LittleEndian, with_unix_fd)
     }
 
     /// Reads from the source once but takes care that the internal buffer only reaches at maximum max_buffer_size
@@ -240,7 +202,9 @@ impl<'msga, 'msge> Conn {
 
         Ok(msg)
     }
+}
 
+impl SendConn {
     /// get the next new serial
     pub fn alloc_serial(&mut self) -> u32 {
         let serial = self.serial_counter;
@@ -264,7 +228,7 @@ impl<'msga, 'msge> Conn {
             (true, serial)
         };
 
-        marshal::marshal(&msg, ByteOrder::LittleEndian, &[], &mut self.msg_buf_out)?;
+        marshal::marshal(&msg, self.byteorder, &mut self.msg_buf_out)?;
 
         let iov = [IoVec::from_slice(&self.msg_buf_out)];
         let flags = MsgFlags::empty();
@@ -311,10 +275,76 @@ impl<'msga, 'msge> Conn {
     }
 }
 
-impl AsRawFd for Conn {
+impl DuplexConn {
+    /// Connect to a unix socket and choose a byteorder
+    pub fn connect_to_bus_with_byteorder(
+        addr: UnixAddr,
+        byteorder: ByteOrder,
+        with_unix_fd: bool,
+    ) -> super::Result<DuplexConn> {
+        let sock = socket(
+            socket::AddressFamily::Unix,
+            socket::SockType::Stream,
+            socket::SockFlag::empty(),
+            None,
+        )?;
+        let sock_addr = SockAddr::Unix(addr);
+        connect(sock, &sock_addr)?;
+        let mut stream = unsafe { UnixStream::from_raw_fd(sock) };
+        match auth::do_auth(&mut stream)? {
+            auth::AuthResult::Ok => {}
+            auth::AuthResult::Rejected => return Err(Error::AuthFailed),
+        }
+
+        if with_unix_fd {
+            match auth::negotiate_unix_fds(&mut stream)? {
+                auth::AuthResult::Ok => {}
+                auth::AuthResult::Rejected => return Err(Error::UnixFdNegotiationFailed),
+            }
+        }
+
+        auth::send_begin(&mut stream)?;
+
+        Ok(DuplexConn {
+            send: SendConn {
+                socket_addr: addr,
+                stream: stream.try_clone()?,
+                msg_buf_out: Vec::new(),
+                byteorder,
+                serial_counter: 1,
+            },
+            recv: RecvConn {
+                msg_buf_in: Vec::new(),
+                cmsgs_in: Vec::new(),
+                stream,
+            },
+        })
+    }
+
+    /// Connect to a unix socket. The default little endian byteorder is used
+    pub fn connect_to_bus(addr: UnixAddr, with_unix_fd: bool) -> Result<DuplexConn> {
+        Self::connect_to_bus_with_byteorder(addr, ByteOrder::LittleEndian, with_unix_fd)
+    }
+}
+
+impl AsRawFd for SendConn {
     /// Reading or writing to the `RawFd` may result in undefined behavior
     /// and break the `Conn`.
     fn as_raw_fd(&self) -> RawFd {
         self.stream.as_raw_fd()
+    }
+}
+impl AsRawFd for RecvConn {
+    /// Reading or writing to the `RawFd` may result in undefined behavior
+    /// and break the `Conn`.
+    fn as_raw_fd(&self) -> RawFd {
+        self.stream.as_raw_fd()
+    }
+}
+impl AsRawFd for DuplexConn {
+    /// Reading or writing to the `RawFd` may result in undefined behavior
+    /// and break the `Conn`.
+    fn as_raw_fd(&self) -> RawFd {
+        self.recv.stream.as_raw_fd()
     }
 }

--- a/rustbus/src/lib.rs
+++ b/rustbus/src/lib.rs
@@ -3,12 +3,12 @@
 //! in the src/bin directory but the gist is:
 //!
 //! ```rust,no_run
-//! use rustbus::{get_session_bus_path, standard_messages, Conn, MessageBuilder, connection::Timeout};
+//! use rustbus::{get_session_bus_path, standard_messages, DuplexConn, MessageBuilder, connection::Timeout};
 //!
 //! fn main() -> Result<(), rustbus::connection::Error> {
 //!     // Connect to the session bus
 //!     let session_path = get_session_bus_path()?;
-//!     let con = Conn::connect_to_bus(session_path, true)?;
+//!     let con = DuplexConn::connect_to_bus(session_path, true)?;
 //!
 //!     // Wrap the con in an RpcConnection which provides many convenient functions
 //!     let mut rpc_con = rustbus::connection::rpc_conn::RpcConn::new(con);
@@ -59,7 +59,9 @@ pub mod wire;
 pub use message_builder::MessageType;
 
 // needed to create a connection
-pub use connection::ll_conn::Conn;
+pub use connection::ll_conn::DuplexConn;
+pub use connection::ll_conn::RecvConn;
+pub use connection::ll_conn::SendConn;
 pub use connection::rpc_conn::RpcConn;
 pub use connection::{get_session_bus_path, get_system_bus_path};
 

--- a/rustbus/src/peer/peer_handling.rs
+++ b/rustbus/src/peer/peer_handling.rs
@@ -1,5 +1,5 @@
 use crate::connection;
-use crate::connection::ll_conn::Conn;
+use crate::connection::ll_conn::DuplexConn;
 use crate::message_builder::DynamicHeader;
 use crate::params::message::Message;
 
@@ -69,7 +69,7 @@ fn get_machine_id() -> Result<String, std::io::Error> {
 /// of that interface and an Error if there were any while handling the message
 pub fn handle_peer_message(
     msg: &Message,
-    con: &mut Conn,
+    con: &mut DuplexConn,
     timeout: connection::Timeout,
 ) -> Result<bool, crate::connection::Error> {
     if let Some(interface) = &msg.dynheader.interface {
@@ -78,13 +78,13 @@ pub fn handle_peer_message(
                 match member.as_str() {
                     "Ping" => {
                         let mut reply = msg.make_response();
-                        con.send_message(&mut reply, timeout)?;
+                        con.send.send_message(&mut reply, timeout)?;
                         Ok(true)
                     }
                     "GetMachineId" => {
                         let mut reply = msg.make_response();
                         reply.body.push_param(get_machine_id().unwrap()).unwrap();
-                        con.send_message(&mut reply, timeout)?;
+                        con.send.send_message(&mut reply, timeout)?;
                         Ok(true)
                     }
 

--- a/rustbus/src/tests/mod.rs
+++ b/rustbus/src/tests/mod.rs
@@ -45,7 +45,7 @@ fn test_marshal_unmarshal() {
 
     msg.dynheader.serial = Some(1);
     let mut buf = Vec::new();
-    marshal(&msg, crate::ByteOrder::LittleEndian, &[], &mut buf).unwrap();
+    marshal(&msg, crate::ByteOrder::LittleEndian, &mut buf).unwrap();
     let (hdrbytes, header) = unmarshal_header(&buf, 0).unwrap();
     let (dynhdrbytes, dynheader) = unmarshal_dynamic_header(&header, &buf, hdrbytes).unwrap();
 
@@ -113,7 +113,7 @@ fn test_invalid_stuff() {
         Err(crate::Error::Validation(
             crate::params::validation::Error::InvalidInterface
         )),
-        marshal(&msg, crate::ByteOrder::LittleEndian, &[], &mut buf)
+        marshal(&msg, crate::ByteOrder::LittleEndian, &mut buf)
     );
 
     // invalid member
@@ -130,6 +130,6 @@ fn test_invalid_stuff() {
         Err(crate::Error::Validation(
             crate::params::validation::Error::InvalidMembername
         )),
-        marshal(&msg, crate::ByteOrder::LittleEndian, &[], &mut buf)
+        marshal(&msg, crate::ByteOrder::LittleEndian, &mut buf)
     );
 }

--- a/rustbus/src/wire/marshal/mod.rs
+++ b/rustbus/src/wire/marshal/mod.rs
@@ -36,10 +36,9 @@ impl MarshalContext<'_, '_> {
 pub fn marshal(
     msg: &crate::message_builder::MarshalledMessage,
     byteorder: ByteOrder,
-    header_fields: &[HeaderField],
     buf: &mut Vec<u8>,
 ) -> message::Result<()> {
-    marshal_header(msg, byteorder, header_fields, buf)?;
+    marshal_header(msg, byteorder, buf)?;
     pad_to_align(8, buf);
     let header_len = buf.len();
 
@@ -54,7 +53,6 @@ pub fn marshal(
 fn marshal_header(
     msg: &crate::message_builder::MarshalledMessage,
     byteorder: ByteOrder,
-    header_fields: &[HeaderField],
     buf: &mut Vec<u8>,
 ) -> message::Result<()> {
     match byteorder {
@@ -124,7 +122,6 @@ fn marshal_header(
         let sig_str = msg.get_sig().to_owned();
         marshal_header_field(byteorder, &HeaderField::Signature(sig_str), buf)?;
     }
-    marshal_header_fields(byteorder, header_fields, buf)?;
     let len = buf.len() - pos - 4; // -4 the bytes for the length indicator do not count
     insert_u32(byteorder, len as u32, &mut buf[pos..pos + 4]);
 

--- a/rustbus/src/wire/marshal/mod.rs
+++ b/rustbus/src/wire/marshal/mod.rs
@@ -217,14 +217,3 @@ fn marshal_header_field(
     }
     Ok(())
 }
-
-fn marshal_header_fields(
-    byteorder: ByteOrder,
-    header_fields: &[HeaderField],
-    buf: &mut Vec<u8>,
-) -> message::Result<()> {
-    for field in header_fields {
-        marshal_header_field(byteorder, field, buf)?;
-    }
-    Ok(())
-}

--- a/rustbus/src/wire/marshal/traits.rs
+++ b/rustbus/src/wire/marshal/traits.rs
@@ -692,7 +692,8 @@ fn test_trait_signature_creation() {
     body.push_param(ObjectPath::new("/a/b").unwrap()).unwrap();
     body.push_param(SignatureWrapper::new("(a{su})").unwrap())
         .unwrap();
-    let fd = crate::wire::UnixFd::new(0);
+
+    let fd = crate::wire::UnixFd::new(nix::unistd::dup(1).unwrap());
     body.push_param(&fd).unwrap();
     body.push_param(true).unwrap();
     body.push_param(0u8).unwrap();
@@ -709,7 +710,6 @@ fn test_trait_signature_creation() {
     body.push_param(&map).unwrap();
 
     assert_eq!("soghbyqutnixaya{s(tuqy)}", msg.get_sig());
-    fd.take_raw_fd(); //prevent accidental closing of real fd
 }
 
 #[test]

--- a/rustbus/src/wire/unixfd.rs
+++ b/rustbus/src/wire/unixfd.rs
@@ -98,7 +98,7 @@ impl UnixFd {
         self.0.take()
     }
 
-    /// Duplicate the underlying FD so you can use it as you will. This is different from just calling 
+    /// Duplicate the underlying FD so you can use it as you will. This is different from just calling
     /// clone(). Clone only makes a new ref to the same underlying FD.
     pub fn dup(&self) -> Option<Result<Self, nix::Error>> {
         match self.0.dup()? {

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -668,7 +668,7 @@ fn test_unmarshal_traits() {
 
     use crate::wire::marshal::traits::{ObjectPath, SignatureWrapper};
     use crate::wire::UnixFd;
-    let orig_fd = UnixFd::new(0);
+    let orig_fd = UnixFd::new(nix::unistd::dup(1).unwrap());
     let orig = (
         ObjectPath::new("/a/b/c").unwrap(),
         SignatureWrapper::new("ss(aiau)").unwrap(),
@@ -695,7 +695,6 @@ fn test_unmarshal_traits() {
 
     assert_eq!(p.as_ref(), "/a/b/c");
     assert_eq!(s.as_ref(), "ss(aiau)");
-    orig_fd.take_raw_fd(); // prevent accidental closing of real fd
 }
 
 #[test]


### PR DESCRIPTION
Merge the result of splitting the low level conn into  two types, one for sending and one for receiving.
This is done to make it possible for the dispatch_conn to provide a `Arc<Mutex<SendConn>>` which in turn allows for sending signals asynchronously to receiving new method calls.