### PR TITLE
Short writes

### DIFF
--- a/example_keywallet/src/bin/client/main.rs
+++ b/example_keywallet/src/bin/client/main.rs
@@ -7,11 +7,7 @@ use rustbus::connection::ll_conn::DuplexConn;
 fn main() {
     let mut con = DuplexConn::connect_to_bus(get_session_bus_path().unwrap(), false).unwrap();
 
-    con.send
-        .send_message(
-            &mut rustbus::standard_messages::hello(),
-            rustbus::connection::Timeout::Infinite,
-        )
+    con.send_hello(rustbus::connection::Timeout::Infinite)
         .unwrap();
 
     let resp = con
@@ -33,7 +29,9 @@ fn main() {
     msg.body.push_param(&attrs).unwrap();
 
     let serial = rpc_conn
-        .send_message(&mut msg, rustbus::connection::Timeout::Infinite)
+        .send_message(&mut msg)
+        .unwrap()
+        .write_all()
         .unwrap();
     let resp = rpc_conn
         .wait_response(serial, rustbus::connection::Timeout::Infinite)

--- a/example_keywallet/src/bin/service/collection_interface.rs
+++ b/example_keywallet/src/bin/service/collection_interface.rs
@@ -42,7 +42,7 @@ pub fn handle_collection_interface(
             let col = ctx
                 .service
                 .get_collection(col_id)
-                .expect(&format!("Collection with ID: {} not found", col_id));
+                .unwrap_or_else(|| panic!("Collection with ID: {} not found", col_id));
             let item_ids = col.search_items(&attrs);
 
             let owned_paths: Vec<(String, &service::Item)> = item_ids
@@ -88,9 +88,9 @@ pub fn handle_collection_interface(
             let col = ctx
                 .service
                 .get_collection_mut(col_id)
-                .expect(&format!("Collection with ID: {} not found", col_id));
+                .unwrap_or_else(|| panic!("Collection with ID: {} not found", col_id));
 
-            let item_id = col.create_item(new_id, &secret, &vec![], replace).unwrap();
+            let item_id = col.create_item(new_id, &secret, &[], replace).unwrap();
             let path = format!("/org/freedesktop/secrets/collection/{}/{}", col_id, item_id);
             let path = ObjectPath::new(&path).unwrap();
 

--- a/example_keywallet/src/bin/service/item_interface.rs
+++ b/example_keywallet/src/bin/service/item_interface.rs
@@ -50,7 +50,7 @@ pub fn handle_item_interface(
                     session: session.to_owned(),
                     params: secret.params.clone(),
                     value: secret.value.clone(),
-                    content_type: secret.content_type.clone(),
+                    content_type: secret.content_type,
                 })
                 .unwrap();
             Ok(Some(resp))

--- a/example_keywallet/src/bin/service/main.rs
+++ b/example_keywallet/src/bin/service/main.rs
@@ -206,13 +206,12 @@ fn main() {
     println!("Unique name: {}", unique_name);
 
     con.send
-        .send_message(
-            &mut rustbus::standard_messages::request_name(
-                "io.killingspark.secrets".into(),
-                rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
-            ),
-            rustbus::connection::Timeout::Infinite,
-        )
+        .send_message(&mut rustbus::standard_messages::request_name(
+            "io.killingspark.secrets".into(),
+            rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
+        ))
+        .unwrap()
+        .write_all()
         .unwrap();
 
     // The responses content should be looked at. ATM we just assume the name aquistion worked...

--- a/example_keywallet/src/bin/service/main.rs
+++ b/example_keywallet/src/bin/service/main.rs
@@ -39,16 +39,16 @@ enum ObjectType<'a> {
 }
 
 fn get_object_type_and_id<'a>(path: &'a ObjectPath<&'a str>) -> Option<ObjectType<'a>> {
-    let mut split = path.as_ref().split("/");
+    let mut split = path.as_ref().split('/');
     let typ = split.nth(3)?;
-    let id = split.nth(0)?;
-    let item_id = split.nth(0);
+    let id = split.next()?;
+    let item_id = split.next();
     match typ {
         "collection" => {
-            if item_id.is_some() {
+            if let Some(item_id) = item_id {
                 Some(ObjectType::Item {
                     col: id,
-                    item: item_id.unwrap(),
+                    item: item_id,
                 })
             } else {
                 Some(ObjectType::Collection(id))
@@ -206,7 +206,7 @@ fn main() {
     println!("Unique name: {}", unique_name);
 
     con.send
-        .send_message(&mut rustbus::standard_messages::request_name(
+        .send_message(&rustbus::standard_messages::request_name(
             "io.killingspark.secrets".into(),
             rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
         ))

--- a/example_keywallet/src/bin/service/service.rs
+++ b/example_keywallet/src/bin/service/service.rs
@@ -1,3 +1,6 @@
+// Because I modeled some stuff I did not need in the end. Might need it thoug to expand this example...
+#![allow(dead_code)]
+
 use example_keywallet::LockState;
 use example_keywallet::LookupAttribute;
 use example_keywallet::Secret;

--- a/rustbus/Cargo.toml
+++ b/rustbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbus"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Moritz Borcherding <moritz.borcherding@web.de>"]
 edition = "2018"
 license = "MIT"

--- a/rustbus/benches/marshal_benchmark.rs
+++ b/rustbus/benches/marshal_benchmark.rs
@@ -8,7 +8,7 @@ use rustbus::wire::unmarshal::unmarshal_header;
 use rustbus::wire::unmarshal::unmarshal_next_message;
 
 fn marsh(msg: &rustbus::message_builder::MarshalledMessage, buf: &mut Vec<u8>) {
-    marshal(msg, rustbus::ByteOrder::LittleEndian, buf).unwrap();
+    marshal(msg, buf).unwrap();
 }
 
 fn unmarshal(buf: &[u8]) {

--- a/rustbus/examples/conn.rs
+++ b/rustbus/examples/conn.rs
@@ -19,7 +19,10 @@ fn main() -> Result<(), rustbus::connection::Error> {
     }));
 
     //println!("Send message: {:?}", hello_msg);
-    let hello_serial = rpc_con.send_message(&mut standard_messages::hello(), Timeout::Infinite)?;
+    let hello_serial = rpc_con
+        .send_message(&mut standard_messages::hello())?
+        .write_all()
+        .unwrap();
 
     println!("\n");
     println!("\n");
@@ -31,10 +34,13 @@ fn main() -> Result<(), rustbus::connection::Error> {
     println!("\n");
     println!("\n");
 
-    let reqname_serial = rpc_con.send_message(
-        &mut standard_messages::request_name("io.killing.spark".into(), 0),
-        Timeout::Infinite,
-    )?;
+    let reqname_serial = rpc_con
+        .send_message(&mut standard_messages::request_name(
+            "io.killing.spark".into(),
+            0,
+        ))?
+        .write_all()
+        .unwrap();
 
     println!("Wait for name request response");
     let msg = rpc_con.wait_response(reqname_serial, Timeout::Infinite)?;
@@ -56,8 +62,10 @@ fn main() -> Result<(), rustbus::connection::Error> {
         panic!("Wrong args: {:?}", msg.params);
     }
 
-    let list_serial =
-        rpc_con.send_message(&mut standard_messages::list_names(), Timeout::Infinite)?;
+    let list_serial = rpc_con
+        .send_message(&mut standard_messages::list_names())?
+        .write_all()
+        .unwrap();
 
     println!("Wait for list response");
     let msg = rpc_con.wait_response(list_serial, Timeout::Infinite)?;
@@ -70,7 +78,10 @@ fn main() -> Result<(), rustbus::connection::Error> {
     let mut sig_listen_msg = standard_messages::add_match("type='signal'".into());
 
     //println!("Send message: {:?}", sig_listen_msg);
-    rpc_con.send_message(&mut sig_listen_msg, Timeout::Infinite)?;
+    rpc_con
+        .send_message(&mut sig_listen_msg)?
+        .write_all()
+        .unwrap();
 
     loop {
         println!("Do important work while signals might arrive");

--- a/rustbus/examples/dispatch.rs
+++ b/rustbus/examples/dispatch.rs
@@ -72,13 +72,12 @@ fn main() {
 
     if std::env::args().find(|arg| "server".eq(arg)).is_some() {
         con.send
-            .send_message(
-                &mut rustbus::standard_messages::request_name(
-                    "killing.spark.io".into(),
-                    rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
-                ),
-                rustbus::connection::Timeout::Infinite,
-            )
+            .send_message(&mut rustbus::standard_messages::request_name(
+                "killing.spark.io".into(),
+                rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
+            ))
+            .unwrap()
+            .write_all()
             .unwrap();
 
         let mut counter = Counter { count: 0 };
@@ -109,7 +108,9 @@ fn main() {
             .on("/ABCD".into())
             .build();
         con.send
-            .send_message(&mut msg1, rustbus::connection::Timeout::Infinite)
+            .send_message(&mut msg1)
+            .unwrap()
+            .write_all()
             .unwrap();
 
         // pick up the name
@@ -119,7 +120,9 @@ fn main() {
             .on("/A/B/moritz".into())
             .build();
         con.send
-            .send_message(&mut msg2, rustbus::connection::Timeout::Infinite)
+            .send_message(&mut msg2)
+            .unwrap()
+            .write_all()
             .unwrap();
 
         // call new handler for that name
@@ -129,13 +132,19 @@ fn main() {
             .on("/moritz".into())
             .build();
         con.send
-            .send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
+            .send_message(&mut msg3)
+            .unwrap()
+            .write_all()
             .unwrap();
         con.send
-            .send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
+            .send_message(&mut msg3)
+            .unwrap()
+            .write_all()
             .unwrap();
         con.send
-            .send_message(&mut msg3, rustbus::connection::Timeout::Infinite)
+            .send_message(&mut msg3)
+            .unwrap()
+            .write_all()
             .unwrap();
     }
 }

--- a/rustbus/examples/sig.rs
+++ b/rustbus/examples/sig.rs
@@ -37,9 +37,9 @@ fn main() -> Result<(), rustbus::connection::Error> {
 
     println!("{:?}", sig);
 
-    con.send.send_message(&mut sig, Timeout::Infinite)?;
+    con.send.send_message(&mut sig)?.write_all().unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
-    con.send.send_message(&mut sig, Timeout::Infinite)?;
+    con.send.send_message(&mut sig)?.write_all().unwrap();
 
     Ok(())
 }

--- a/rustbus/examples/user_defined_types.rs
+++ b/rustbus/examples/user_defined_types.rs
@@ -154,7 +154,7 @@ fn main() -> Result<(), rustbus::connection::Error> {
     sig.body.push_param(MyVar::Int32(100))?;
     sig.body.push_param(MyVar::Int64(-100))?;
 
-    con.send.send_message(&mut sig, Timeout::Infinite)?;
+    con.send.send_message(&mut sig)?.write_all().unwrap();
 
     Ok(())
 }

--- a/rustbus/src/connection/dispatch_conn.rs
+++ b/rustbus/src/connection/dispatch_conn.rs
@@ -232,20 +232,29 @@ impl<UserData, UserError: std::fmt::Debug> DispatchConn<UserData, UserError> {
                         }
                     }
 
-                    match result {
-                        Ok(Some(mut response)) => self
-                            .send
-                            .lock()
-                            .unwrap()
-                            .send_message(&mut response, Timeout::Infinite)
-                            .map_err(|e| (Some(msg), e.into()))?,
+                    let mut send_conn = self.send.lock().unwrap();
 
-                        Ok(None) => self
-                            .send
-                            .lock()
-                            .unwrap()
-                            .send_message(&mut msg.dynheader.make_response(), Timeout::Infinite)
-                            .map_err(|e| (Some(msg), e.into()))?,
+                    match result {
+                        Ok(Some(mut response)) => {
+                            let ctx = match send_conn.send_message(&mut response) {
+                                Ok(ctx) => ctx,
+                                Err(e) => return Err((Some(msg), e.into())),
+                            };
+                            ctx.write_all()
+                                .map_err(|(ctx, e)| ll_conn::force_finish_on_error((ctx, e)))
+                                .map_err(|e| (Some(msg), e.into()))?
+                        }
+
+                        Ok(None) => {
+                            let mut response = msg.dynheader.make_response();
+                            let ctx = match send_conn.send_message(&mut response) {
+                                Ok(ctx) => ctx,
+                                Err(e) => return Err((Some(msg), e.into())),
+                            };
+                            ctx.write_all()
+                                .map_err(|(ctx, e)| ll_conn::force_finish_on_error((ctx, e)))
+                                .map_err(|e| (Some(msg), e.into()))?
+                        }
                         Err(error) => return Err((Some(msg), error)),
                     };
                 }

--- a/rustbus/src/connection/dispatch_conn.rs
+++ b/rustbus/src/connection/dispatch_conn.rs
@@ -235,8 +235,8 @@ impl<UserData, UserError: std::fmt::Debug> DispatchConn<UserData, UserError> {
                     let mut send_conn = self.send.lock().unwrap();
 
                     match result {
-                        Ok(Some(mut response)) => {
-                            let ctx = match send_conn.send_message(&mut response) {
+                        Ok(Some(response)) => {
+                            let ctx = match send_conn.send_message(&response) {
                                 Ok(ctx) => ctx,
                                 Err(e) => return Err((Some(msg), e.into())),
                             };
@@ -246,8 +246,8 @@ impl<UserData, UserError: std::fmt::Debug> DispatchConn<UserData, UserError> {
                         }
 
                         Ok(None) => {
-                            let mut response = msg.dynheader.make_response();
-                            let ctx = match send_conn.send_message(&mut response) {
+                            let response = msg.dynheader.make_response();
+                            let ctx = match send_conn.send_message(&response) {
                                 Ok(ctx) => ctx,
                                 Err(e) => return Err((Some(msg), e.into())),
                             };

--- a/rustbus/src/connection/ll_conn.rs
+++ b/rustbus/src/connection/ll_conn.rs
@@ -312,6 +312,7 @@ impl SendMessageContext<'_> {
         progress
     }
 
+    /// Either drop self and return Ok value or return (self, error)
     fn finish_if_ok<O, E>(
         self,
         res: std::result::Result<O, E>,
@@ -333,6 +334,8 @@ impl SendMessageContext<'_> {
         std::mem::forget(self)
     }
 
+    /// Try writing as many bytes as possible until either no more bytes need to be written or
+    /// the timeout is reached. For an infinite timeout there is write_all as a shortcut
     pub fn write(mut self, timeout: Timeout) -> std::result::Result<u32, (Self, super::Error)> {
         let start_time = std::time::Instant::now();
 
@@ -357,6 +360,7 @@ impl SendMessageContext<'_> {
         self.finish_if_ok(res)
     }
 
+    /// Block until all bytes have been written
     pub fn write_all(self) -> std::result::Result<u32, (Self, super::Error)> {
         self.write(Timeout::Infinite)
     }
@@ -371,7 +375,8 @@ impl SendMessageContext<'_> {
         self.state.bytes_sent == self.bytes_total()
     }
 
-    /// Basic routine to do a write to the fd once
+    /// Basic routine to do a write to the fd once. Mostly useful if you are using a nonblocking timeout. But even then I would recommend using
+    /// write() and not write_once()
     pub fn write_once(&mut self, timeout: Timeout) -> Result<usize> {
         // This will result in a zero sized slice if the header has been sent. Actually we would not need to
         // include that anymore in the iov but that is harder than just giving it the zero sized slice.

--- a/rustbus/src/connection/ll_conn.rs
+++ b/rustbus/src/connection/ll_conn.rs
@@ -480,16 +480,13 @@ impl DuplexConn {
     }
 
     /// Sends the obligatory hello message and returns the unique id the daemon assigned this connection
-    pub fn send_hello<'a>(
-        &'a mut self,
-        timeout: crate::connection::Timeout,
-    ) -> super::Result<String> {
+    pub fn send_hello(&mut self, timeout: crate::connection::Timeout) -> super::Result<String> {
         let start_time = time::Instant::now();
 
-        let mut hello = crate::standard_messages::hello();
+        let hello = crate::standard_messages::hello();
         let serial = self
             .send
-            .send_message(&mut hello)?
+            .send_message(&hello)?
             .write(super::calc_timeout_left(&start_time, timeout)?)
             .map_err(|(ctx, e)| {
                 ctx.force_finish();

--- a/rustbus/src/connection/rpc_conn.rs
+++ b/rustbus/src/connection/rpc_conn.rs
@@ -80,18 +80,24 @@ impl RpcConn {
 
     pub fn session_conn(timeout: Timeout) -> Result<Self> {
         let session_path = get_session_bus_path()?;
-        let con = DuplexConn::connect_to_bus(session_path, true)?;
-        let mut con = Self::new(con);
-        let serial = con.send_message(&mut crate::standard_messages::hello(), Timeout::Infinite)?;
-        con.wait_response(serial, timeout)?;
-        Ok(con)
+        Self::connect_to_path(session_path, timeout)
     }
 
     pub fn system_conn(timeout: Timeout) -> Result<Self> {
         let session_path = get_system_bus_path()?;
-        let con = DuplexConn::connect_to_bus(session_path, true)?;
+        Self::connect_to_path(session_path, timeout)
+    }
+
+    pub fn connect_to_path(path: UnixAddr, timeout: Timeout) -> Result<Self> {
+        let con = DuplexConn::connect_to_bus(path, true)?;
         let mut con = Self::new(con);
-        let serial = con.send_message(&mut crate::standard_messages::hello(), Timeout::Infinite)?;
+
+        let mut hello = crate::standard_messages::hello();
+        let serial = con
+            .send_message(&mut hello)?
+            .write(timeout)
+            .map_err(super::ll_conn::force_finish_on_error)?;
+
         con.wait_response(serial, timeout)?;
         Ok(con)
     }
@@ -146,20 +152,14 @@ impl RpcConn {
     }
 
     /// Send a message to the bus
-    pub fn send_message(
-        &mut self,
-        msg: &mut crate::message_builder::MarshalledMessage,
-        timeout: Timeout,
-    ) -> Result<u32> {
-        self.conn.send.send_message(msg, timeout)
+    pub fn send_message<'a>(
+        &'a mut self,
+        msg: &'a mut crate::message_builder::MarshalledMessage,
+    ) -> Result<super::ll_conn::SendMessageContext<'a>> {
+        self.conn.send.send_message(msg)
     }
 
-    fn insert_message_or_send_error(
-        &mut self,
-        msg: MarshalledMessage,
-        timeout: Timeout,
-    ) -> Result<()> {
-        let start_time = time::Instant::now();
+    fn insert_message_or_send_error(&mut self, msg: MarshalledMessage) -> Result<()> {
         if self.filter.as_ref()(&msg) {
             match msg.typ {
                 MessageType::Call => {
@@ -184,7 +184,9 @@ impl RpcConn {
                     let mut reply = crate::standard_messages::unknown_method(&msg.dynheader);
                     self.conn
                         .send
-                        .send_message(&mut reply, calc_timeout_left(&start_time, timeout)?)?;
+                        .send_message(&mut reply)?
+                        .write_all()
+                        .map_err(ll_conn::force_finish_on_error)?;
                 }
                 MessageType::Invalid => return Err(Error::UnexpectedTypeReceived),
                 MessageType::Error => {
@@ -213,7 +215,7 @@ impl RpcConn {
             .get_next_message(calc_timeout_left(&start_time, timeout)?)?;
 
         let typ = msg.typ;
-        self.insert_message_or_send_error(msg, calc_timeout_left(&start_time, timeout)?)?;
+        self.insert_message_or_send_error(msg)?;
         Ok(Some(typ))
     }
 

--- a/rustbus/src/connection/rpc_conn.rs
+++ b/rustbus/src/connection/rpc_conn.rs
@@ -181,10 +181,10 @@ impl RpcConn {
         } else {
             match msg.typ {
                 MessageType::Call => {
-                    let mut reply = crate::standard_messages::unknown_method(&msg.dynheader);
+                    let reply = crate::standard_messages::unknown_method(&msg.dynheader);
                     self.conn
                         .send
-                        .send_message(&mut reply)?
+                        .send_message(&reply)?
                         .write_all()
                         .map_err(ll_conn::force_finish_on_error)?;
                 }

--- a/rustbus/src/lib.rs
+++ b/rustbus/src/lib.rs
@@ -32,7 +32,7 @@
 //!     
 //!     // Now you can inspect the message.dynheader for all the metadata on the message
 //!     println!("The messages dynamic header: {:?}", message.dynheader);
-//! 
+//!
 //!     // After inspecting that dynheader you should know which content the message should contain
 //!     let cool_string = message.body.parser().get::<&str>().unwrap();
 //!     println!("Received a cool string: {}", cool_string);
@@ -40,18 +40,18 @@
 //! ```
 //!
 //! ## Other connection Types
-//! There are some more connection types in the connection module. These are convenience wrappes around the concepts presented in the quickstart. 
+//! There are some more connection types in the connection module. These are convenience wrappes around the concepts presented in the quickstart.
 //! * RpcConn is meant for clients calling methods on services on the bus
 //! * DispatchConn is meant for services that need to dispatch calls to many handlers.
-//! 
+//!
 //! Since different usecases have diffenret constraints you might need to write your own wrapper around the low level conn. This should not be too hard
-//! if you copy the existing ones and modify them to your needs. If you have an issue that would be helpful for others I would of course consider adding 
+//! if you copy the existing ones and modify them to your needs. If you have an issue that would be helpful for others I would of course consider adding
 //! it to this libary.
-//! 
+//!
 //! ## Params and Marshal and Unmarshal
 //! This lib started out as an attempt to understand how dbus worked. Thus I modeled the types a closely as possible with enums, which is still in the params module.
 //! This is kept around for weird weird edge-cases where that might be necessary but they should not generally be used.
-//! 
+//!
 //! Instead you should be using the Marshal and Unmarshal traits which are implemented for most common types you will need.
 
 pub mod auth;

--- a/rustbus/src/lib.rs
+++ b/rustbus/src/lib.rs
@@ -2,7 +2,7 @@
 //! Rustbus is a dbus library that allows for clients to perform method_calls on services on the bus or to implement your own service that listens on the bus.
 //!
 //! ## Quickstart
-//! ```rust
+//! ```rust,no_run
 //! use rustbus::{connection::Timeout, get_session_bus_path, DuplexConn, MessageBuilder, connection::ll_conn::force_finish_on_error};
 //! fn main() -> Result<(), rustbus::connection::Error> {
 //!     /// To get a connection going you need to connect to a bus. You will likely use either the session or the system bus.

--- a/rustbus/src/lib.rs
+++ b/rustbus/src/lib.rs
@@ -3,11 +3,11 @@
 //!
 //! ## Quickstart
 //! ```rust
-//! use rustbus::{connection::Timeout, get_session_bus_path, DuplexConn, MessageBuilder};
+//! use rustbus::{connection::Timeout, get_session_bus_path, DuplexConn, MessageBuilder, connection::ll_conn::force_finish_on_error};
 //! fn main() -> Result<(), rustbus::connection::Error> {
 //!     /// To get a connection going you need to connect to a bus. You will likely use either the session or the system bus.
 //!     let session_path = get_session_bus_path()?;
-//!     let con = DuplexConn::connect_to_bus(session_path, true)?;
+//!     let mut con = DuplexConn::connect_to_bus(session_path, true)?;
 //!     // Dont forget to send the obligatory hello message. send_hello wraps the call and parses the response for convenience.
 //!     let unique_name = con.send_hello(Timeout::Infinite)?;
 //!
@@ -25,7 +25,7 @@
 //!     sig.body.push_param("My cool new Signal!").unwrap();
 //!     
 //!     // Now send you signal to all that want to hear it!
-//!     con.send.send_message(&mut sig, Timeout::Infinite)?;
+//!     con.send.send_message(&sig)?.write_all().map_err(force_finish_on_error)?;
 //!     
 //!     // To receive messages sent to you you can call the various functions on the RecvConn. The simplest is this:
 //!     let message = con.recv.get_next_message(Timeout::Infinite)?;  
@@ -36,6 +36,7 @@
 //!     // After inspecting that dynheader you should know which content the message should contain
 //!     let cool_string = message.body.parser().get::<&str>().unwrap();
 //!     println!("Received a cool string: {}", cool_string);
+//!     Ok(())
 //! }
 //! ```
 //!

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -282,7 +282,7 @@ pub struct MarshalledMessageBody {
     pub(crate) raw_fds: Vec<crate::wire::UnixFd>,
 
     sig: String,
-    byteorder: ByteOrder,
+    pub(crate) byteorder: ByteOrder,
 }
 
 impl Default for MarshalledMessageBody {

--- a/rustbus/src/params/validation.rs
+++ b/rustbus/src/params/validation.rs
@@ -65,6 +65,9 @@ pub fn validate_interface(int: &str) -> Result<()> {
         if element.is_empty() {
             return Err(Error::InvalidInterface);
         }
+        if let Some(true) = element.chars().next().map(|c| c.is_numeric()) {
+            return Err(Error::InvalidInterface);
+        }
         let alphanum_or_underscore = element.chars().all(|c| c.is_alphanumeric() || c == '_');
         if !alphanum_or_underscore {
             return Err(Error::InvalidInterface);

--- a/rustbus/src/params/validation.rs
+++ b/rustbus/src/params/validation.rs
@@ -41,9 +41,6 @@ pub fn validate_object_path(op: &str) -> Result<()> {
             if element.is_empty() {
                 return Err(Error::InvalidObjectPath);
             }
-            if let Some(true) = element.chars().next().map(|c| c.is_numeric()) {
-                return Err(Error::InvalidObjectPath);
-            }
             let alphanum_or_underscore = element.chars().all(|c| c.is_alphanumeric() || c == '_');
             if !alphanum_or_underscore {
                 return Err(Error::InvalidObjectPath);

--- a/rustbus/src/params/validation.rs
+++ b/rustbus/src/params/validation.rs
@@ -65,9 +65,6 @@ pub fn validate_interface(int: &str) -> Result<()> {
         if element.is_empty() {
             return Err(Error::InvalidInterface);
         }
-        if let Some(true) = element.chars().next().map(|c| c.is_numeric()) {
-            return Err(Error::InvalidInterface);
-        }
         let alphanum_or_underscore = element.chars().all(|c| c.is_alphanumeric() || c == '_');
         if !alphanum_or_underscore {
             return Err(Error::InvalidInterface);

--- a/rustbus/src/tests/dbus_send.rs
+++ b/rustbus/src/tests/dbus_send.rs
@@ -1,3 +1,4 @@
+use crate::connection::ll_conn::force_finish_on_error;
 use crate::connection::rpc_conn::RpcConn;
 use crate::connection::Timeout;
 use crate::standard_messages;
@@ -20,29 +21,32 @@ fn test_dbus_send_comp() -> Result<(), crate::connection::Error> {
             .eq(&Some("io.killing.spark.dbustest".to_owned())),
     }));
 
-    let hello_serial = rpc_con.send_message(
-        &mut standard_messages::hello(),
-        Timeout::Duration(std::time::Duration::from_millis(10)),
-    )?;
+    let hello_serial = rpc_con
+        .send_message(&mut standard_messages::hello())?
+        .write_all()
+        .map_err(force_finish_on_error)?;
     let _msg = rpc_con.wait_response(
         hello_serial,
         Timeout::Duration(std::time::Duration::from_millis(10)),
     )?;
 
     // Request name
-    let reqname_serial = rpc_con.send_message(
-        &mut standard_messages::request_name("io.killing.spark.dbustest".into(), 0),
-        Timeout::Duration(std::time::Duration::from_millis(10)),
-    )?;
+    let reqname_serial = rpc_con
+        .send_message(&mut standard_messages::request_name(
+            "io.killing.spark.dbustest".into(),
+            0,
+        ))?
+        .write_all()
+        .map_err(force_finish_on_error)?;
     let _msg = rpc_con.wait_response(
         reqname_serial,
         Timeout::Duration(std::time::Duration::from_millis(10)),
     )?;
 
-    let sig_serial = rpc_con.send_message(
-        &mut standard_messages::add_match("type='signal'".into()),
-        Timeout::Duration(std::time::Duration::from_millis(10)),
-    )?;
+    let sig_serial = rpc_con
+        .send_message(&mut standard_messages::add_match("type='signal'".into()))?
+        .write_all()
+        .map_err(force_finish_on_error)?;
     let _msg = rpc_con.wait_response(
         sig_serial,
         Timeout::Duration(std::time::Duration::from_millis(10)),

--- a/rustbus/src/tests/mod.rs
+++ b/rustbus/src/tests/mod.rs
@@ -45,7 +45,7 @@ fn test_marshal_unmarshal() {
 
     msg.dynheader.serial = Some(1);
     let mut buf = Vec::new();
-    marshal(&msg, 0, crate::ByteOrder::LittleEndian, &mut buf).unwrap();
+    marshal(&msg, 0, &mut buf).unwrap();
     let (hdrbytes, header) = unmarshal_header(&buf, 0).unwrap();
     let (dynhdrbytes, dynheader) = unmarshal_dynamic_header(&header, &buf, hdrbytes).unwrap();
 
@@ -115,7 +115,7 @@ fn test_invalid_stuff() {
         Err(crate::Error::Validation(
             crate::params::validation::Error::InvalidInterface
         )),
-        marshal(&msg, 0, crate::ByteOrder::LittleEndian, &mut buf)
+        marshal(&msg, 0, &mut buf)
     );
 
     // invalid member
@@ -132,6 +132,6 @@ fn test_invalid_stuff() {
         Err(crate::Error::Validation(
             crate::params::validation::Error::InvalidMembername
         )),
-        marshal(&msg, 0, crate::ByteOrder::LittleEndian, &mut buf)
+        marshal(&msg, 0, &mut buf)
     );
 }

--- a/rustbus/src/tests/mod.rs
+++ b/rustbus/src/tests/mod.rs
@@ -45,12 +45,14 @@ fn test_marshal_unmarshal() {
 
     msg.dynheader.serial = Some(1);
     let mut buf = Vec::new();
-    marshal(&msg, crate::ByteOrder::LittleEndian, &mut buf).unwrap();
+    marshal(&msg, 0, crate::ByteOrder::LittleEndian, &mut buf).unwrap();
     let (hdrbytes, header) = unmarshal_header(&buf, 0).unwrap();
     let (dynhdrbytes, dynheader) = unmarshal_dynamic_header(&header, &buf, hdrbytes).unwrap();
 
-    let (_, unmarshed_msg) =
-        unmarshal_next_message(&header, dynheader, &buf, hdrbytes + dynhdrbytes).unwrap();
+    let headers_plus_padding = hdrbytes + dynhdrbytes + (8 - ((hdrbytes + dynhdrbytes) % 8));
+    assert_eq!(headers_plus_padding, buf.len());
+
+    let (_, unmarshed_msg) = unmarshal_next_message(&header, dynheader, msg.get_buf(), 0).unwrap();
 
     let msg = unmarshed_msg.unmarshall_all().unwrap();
 
@@ -94,7 +96,7 @@ fn test_invalid_stuff() {
         .push_old_param(&Param::Base(Base::ObjectPath("invalid/object/path".into())));
     assert_eq!(
         Err(crate::Error::Validation(
-            crate::params::validation::Error::InvalidObjectPath
+            crate::params::validation::Error::InvalidObjectPath("invalid/object/path".to_owned())
         )),
         err
     );
@@ -113,7 +115,7 @@ fn test_invalid_stuff() {
         Err(crate::Error::Validation(
             crate::params::validation::Error::InvalidInterface
         )),
-        marshal(&msg, crate::ByteOrder::LittleEndian, &mut buf)
+        marshal(&msg, 0, crate::ByteOrder::LittleEndian, &mut buf)
     );
 
     // invalid member
@@ -130,6 +132,6 @@ fn test_invalid_stuff() {
         Err(crate::Error::Validation(
             crate::params::validation::Error::InvalidMembername
         )),
-        marshal(&msg, crate::ByteOrder::LittleEndian, &mut buf)
+        marshal(&msg, 0, crate::ByteOrder::LittleEndian, &mut buf)
     );
 }

--- a/rustbus/src/tests/mod.rs
+++ b/rustbus/src/tests/mod.rs
@@ -96,7 +96,7 @@ fn test_invalid_stuff() {
         .push_old_param(&Param::Base(Base::ObjectPath("invalid/object/path".into())));
     assert_eq!(
         Err(crate::Error::Validation(
-            crate::params::validation::Error::InvalidObjectPath("invalid/object/path".to_owned())
+            crate::params::validation::Error::InvalidObjectPath
         )),
         err
     );

--- a/rustbus/src/wire/marshal/mod.rs
+++ b/rustbus/src/wire/marshal/mod.rs
@@ -33,7 +33,8 @@ impl MarshalContext<'_, '_> {
     }
 }
 
-/// This ignores the serial in the message and always uses chosen_serial.
+/// This only prepares the header and dynheader fields. To send a message you still need the original message
+/// and use get_buf() to get to the contents
 pub fn marshal(
     msg: &crate::message_builder::MarshalledMessage,
     chosen_serial: u32,
@@ -42,13 +43,9 @@ pub fn marshal(
 ) -> message::Result<()> {
     marshal_header(msg, chosen_serial, byteorder, buf)?;
     pad_to_align(8, buf);
-    let header_len = buf.len();
-
-    buf.extend_from_slice(msg.get_buf());
 
     // set the correct message length
-    let body_len = buf.len() - header_len;
-    insert_u32(byteorder, body_len as u32, &mut buf[4..8]);
+    insert_u32(byteorder, msg.get_buf().len() as u32, &mut buf[4..8]);
     Ok(())
 }
 
@@ -87,10 +84,7 @@ fn marshal_header(
     buf.push(0);
     buf.push(0);
 
-    match msg.dynheader.serial {
-        Some(serial) => write_u32(serial, byteorder, buf),
-        None => return Err(crate::wire::unmarshal::Error::NoSerial.into()),
-    }
+    write_u32(chosen_serial, byteorder, buf);
 
     // Zero bytes where the length of the header fields will be put
     let pos = buf.len();
@@ -99,7 +93,9 @@ fn marshal_header(
     buf.push(0);
     buf.push(0);
 
-    marshal_header_field(byteorder, &HeaderField::ReplySerial(chosen_serial), buf)?;
+    if let Some(serial) = &msg.dynheader.response_serial {
+        marshal_header_field(byteorder, &HeaderField::ReplySerial(*serial), buf)?;
+    }
     if let Some(int) = &msg.dynheader.interface {
         marshal_header_field(byteorder, &HeaderField::Interface(int.clone()), buf)?;
     }

--- a/rustbus/src/wire/marshal/mod.rs
+++ b/rustbus/src/wire/marshal/mod.rs
@@ -38,23 +38,27 @@ impl MarshalContext<'_, '_> {
 pub fn marshal(
     msg: &crate::message_builder::MarshalledMessage,
     chosen_serial: u32,
-    byteorder: ByteOrder,
     buf: &mut Vec<u8>,
 ) -> message::Result<()> {
-    marshal_header(msg, chosen_serial, byteorder, buf)?;
+    marshal_header(msg, chosen_serial, buf)?;
     pad_to_align(8, buf);
 
     // set the correct message length
-    insert_u32(byteorder, msg.get_buf().len() as u32, &mut buf[4..8]);
+    insert_u32(
+        msg.body.byteorder,
+        msg.get_buf().len() as u32,
+        &mut buf[4..8],
+    );
     Ok(())
 }
 
 fn marshal_header(
     msg: &crate::message_builder::MarshalledMessage,
     chosen_serial: u32,
-    byteorder: ByteOrder,
     buf: &mut Vec<u8>,
 ) -> message::Result<()> {
+    let byteorder = msg.body.byteorder;
+
     match byteorder {
         ByteOrder::BigEndian => {
             buf.push(b'B');

--- a/rustbus/src/wire/unixfd.rs
+++ b/rustbus/src/wire/unixfd.rs
@@ -181,13 +181,13 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for UnixFd {
 fn test_fd_send() {
     let x = UnixFd::new(nix::unistd::dup(1).unwrap());
     std::thread::spawn(move || {
-        println!("Hey the fd {} is Send!!!!", x.get_raw_fd().unwrap());
+        let _x = x.get_raw_fd();
     });
 
     let x = UnixFd::new(nix::unistd::dup(1).unwrap());
     let fd = crate::params::Base::UnixFd(x);
     std::thread::spawn(move || {
-        println!("Hey the fd {:?} is Send!!!!", fd);
+        let _x = fd;
     });
 }
 


### PR DESCRIPTION
This branch implements primitives for handling short writes on the connection by providing means to resume sending through a `SendMessageContext`.