### PR TITLE
Add MarshalledMessageBody::validate()

### DIFF
--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -482,6 +482,9 @@ impl MarshalledMessageBody {
     }
     /// Validate the all the marshalled elements of the body.
     pub fn validate(&self) -> Result<(), crate::wire::unmarshal::Error> {
+        if self.sig.len() == 0 {
+            return Ok(());
+        }
         let types = crate::signature::Type::parse_description(&self.sig)?;
         let mut used = 0;
         for typ in types {

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -5,6 +5,7 @@ use crate::wire::marshal::traits::Marshal;
 use crate::wire::marshal::MarshalContext;
 use crate::wire::unixfd::UnixFd;
 use crate::wire::unmarshal::UnmarshalContext;
+use crate::wire::validate_raw;
 use crate::ByteOrder;
 
 /// Types a message might have
@@ -479,7 +480,20 @@ impl MarshalledMessageBody {
         self.sig.push('v');
         marshal_as_variant(p, self.byteorder, &mut self.buf, &mut self.raw_fds)
     }
-
+    /// Validate the all the marshalled elements of the body.
+    pub fn validate(&self) -> Result<(), crate::wire::unmarshal::Error> {
+        let types = crate::signature::Type::parse_description(&self.sig)?;
+        let mut used = 0;
+        for typ in types {
+            used += validate_raw::validate_marshalled(self.byteorder, used, &self.buf, &typ)
+                .map_err(|(_, e)| e)?;
+        }
+        if used == self.buf.len() {
+            Ok(())
+        } else {
+            Err(crate::wire::unmarshal::Error::NotAllBytesUsed)
+        }
+    }
     /// Create a parser to retrieve parameters from the body.
     #[inline]
     pub fn parser(&self) -> MessageBodyParser {

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -482,7 +482,7 @@ impl MarshalledMessageBody {
     }
     /// Validate the all the marshalled elements of the body.
     pub fn validate(&self) -> Result<(), crate::wire::unmarshal::Error> {
-        if self.sig.len() == 0 {
+        if self.sig.is_empty() && self.buf.is_empty() {
             return Ok(());
         }
         let types = crate::signature::Type::parse_description(&self.sig)?;


### PR DESCRIPTION
Useful if you used the `from_parts` method to build a marshalled message and want to check if it valid.