### PR TITLE
Optimize validate_marshalled_container when unmarshalling simple types.

### DIFF
--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -5,6 +5,7 @@ use crate::wire::marshal::traits::Marshal;
 use crate::wire::marshal::MarshalContext;
 use crate::wire::unixfd::UnixFd;
 use crate::wire::unmarshal::UnmarshalContext;
+use crate::wire::validate_raw;
 use crate::ByteOrder;
 
 /// Types a message might have
@@ -479,7 +480,20 @@ impl MarshalledMessageBody {
         self.sig.push('v');
         marshal_as_variant(p, self.byteorder, &mut self.buf, &mut self.raw_fds)
     }
-
+    /// Validate the all the marshalled elements of the body.
+    pub fn validate(&self) -> Result<(), crate::wire::unmarshal::Error> {
+        let types = crate::signature::Type::parse_description(&self.sig)?;
+        let mut used = 0;
+        for typ in types {
+            used += validate_raw::validate_marshalled(self.byteorder, used, &self.buf, &typ)
+                .map_err(|(_, e)| e)?;
+        }
+        if used == self.buf.len() {
+            Ok(())
+        } else {
+            Err(crate::wire::unmarshal::Error::NotAllBytesUsed)
+        }
+    }
     /// Create a parser to retrieve parameters from the body.
     #[inline]
     pub fn parser(&self) -> MessageBodyParser {

--- a/rustbus/src/signature.rs
+++ b/rustbus/src/signature.rs
@@ -192,7 +192,6 @@ impl Base {
             Base::Signature => buf.push('g'),
         }
     }
-
     pub fn get_alignment(self) -> usize {
         match self {
             Base::Boolean => 4,
@@ -208,6 +207,23 @@ impl Base {
             Base::String => 4,
             Base::ObjectPath => 4,
             Base::Signature => 1,
+        }
+    }
+    /// If every bit-pattern is valid for a type and
+    /// and the length of the type is a multiple of its
+    /// alignment then this will return true.
+    pub(crate) fn bytes_always_valid(&self) -> bool {
+        match self {
+            Base::Byte => true,
+            Base::Int16 => true,
+            Base::Uint16 => true,
+            Base::Int32 => true,
+            Base::Uint32 => true,
+            Base::Int64 => true,
+            Base::Uint64 => true,
+            Base::UnixFd => true,
+            Base::Double => true,
+            _ => false,
         }
     }
 }
@@ -268,7 +284,12 @@ impl Type {
             Type::Container(c) => c.get_alignment(),
         }
     }
-
+    pub(crate) fn bytes_always_valid(&self) -> bool {
+        match self {
+            Type::Base(b) => b.bytes_always_valid(),
+            Type::Container(_) => false,
+        }
+    }
     fn parse_next_type<I: Iterator<Item = Result<Token>>>(
         tokens: &mut I,
         delim: Option<Token>,

--- a/rustbus/src/wire/validate_raw.rs
+++ b/rustbus/src/wire/validate_raw.rs
@@ -313,3 +313,11 @@ fn test_raw_validation() {
     )
     .unwrap();
 }
+#[test]
+fn test_array_element_overflow() {
+    let mut buf = vec![10, 0, 0, 0, 10, 0, 0, 0];
+    buf.resize(18, 0x61);
+    buf.push(0);
+    let typ = &signature::Type::parse_description("as").unwrap();
+    validate_marshalled(ByteOrder::LittleEndian, 0, &buf, &typ[0]).unwrap_err();
+}


### PR DESCRIPTION
When validating integer types and doubles, any bit-pattern is valid. When validating an array of just these types, you can skip validating each element individually. 

This improves the runtime of validating arrays of these always-valid-types from O(n) to O(1).

Also a bug was fixed in validating arrays that allowed for the last element to overflow the array.