### PR TITLE
Optimize validate_marshalled_container when unmarshalling simple types.

### DIFF
--- a/rustbus/src/signature.rs
+++ b/rustbus/src/signature.rs
@@ -213,18 +213,17 @@ impl Base {
     /// and the length of the type is equal to its alignment
     /// return true.
     pub(crate) fn bytes_always_valid(&self) -> bool {
-        match self {
-            Base::Byte => true,
-            Base::Int16 => true,
-            Base::Uint16 => true,
-            Base::Int32 => true,
-            Base::Uint32 => true,
-            Base::Int64 => true,
-            Base::Uint64 => true,
-            Base::UnixFd => true,
-            Base::Double => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Base::Byte
+                | Base::Int16
+                | Base::Uint16
+                | Base::Uint32
+                | Base::Int64
+                | Base::Uint64
+                | Base::UnixFd
+                | Base::Double
+        )
     }
 }
 

--- a/rustbus/src/signature.rs
+++ b/rustbus/src/signature.rs
@@ -210,8 +210,8 @@ impl Base {
         }
     }
     /// If every bit-pattern is valid for a type and
-    /// and the length of the type is a multiple of its
-    /// alignment then this will return true.
+    /// and the length of the type is equal to its alignment
+    /// return true.
     pub(crate) fn bytes_always_valid(&self) -> bool {
         match self {
             Base::Byte => true,
@@ -284,6 +284,9 @@ impl Type {
             Type::Container(c) => c.get_alignment(),
         }
     }
+    /// If every bit-pattern is valid for a type and
+    /// and the length of the type is equal to its alignment
+    /// return true.
     pub(crate) fn bytes_always_valid(&self) -> bool {
         match self {
             Type::Base(b) => b.bytes_always_valid(),

--- a/rustbus/src/signature.rs
+++ b/rustbus/src/signature.rs
@@ -192,7 +192,6 @@ impl Base {
             Base::Signature => buf.push('g'),
         }
     }
-
     pub fn get_alignment(self) -> usize {
         match self {
             Base::Boolean => 4,
@@ -208,6 +207,23 @@ impl Base {
             Base::String => 4,
             Base::ObjectPath => 4,
             Base::Signature => 1,
+        }
+    }
+    /// If every bit-pattern is valid for a type and
+    /// and the length of the type is a multiple of its
+    /// alignment then this will return true.
+    pub(crate) fn bytes_always_valid(&self) -> bool {
+        match self {
+            Base::Byte => true,
+            Base::Int16 => true,
+            Base::Uint16 => true,
+            Base::Int32 => true,
+            Base::Uint32 => true,
+            Base::Int64 => true,
+            Base::Uint64 => true,
+            Base::UnixFd => true,
+            Base::Double => true,
+            _ => false,
         }
     }
 }
@@ -268,7 +284,12 @@ impl Type {
             Type::Container(c) => c.get_alignment(),
         }
     }
-
+    pub(crate) fn bytes_always_valid(&self) -> bool {
+        match self {
+            Type::Base(b) => b.bytes_always_valid(),
+            Type::Container(_) => false,
+        }
+    }
     fn parse_next_type<I: Iterator<Item = Result<Token>>>(
         tokens: &mut I,
         delim: Option<Token>,

--- a/rustbus/src/wire/validate_raw.rs
+++ b/rustbus/src/wire/validate_raw.rs
@@ -313,3 +313,11 @@ fn test_raw_validation() {
     )
     .unwrap();
 }
+#[test]
+fn test_array_element_overflow() {
+    let mut buf = vec![10, 0, 0, 0, 10, 0, 0, 0];
+    buf.resize(18, 0x61);
+    buf.push(0);
+    let typ = &signature::Type::parse_description("as").unwrap();
+    validate_marshalled(ByteOrder::LittleEndian, 0, &buf, &typ[0]).unwrap_err();
+}

--- a/rustbus/src/wire/validate_raw.rs
+++ b/rustbus/src/wire/validate_raw.rs
@@ -152,7 +152,10 @@ pub fn validate_marshalled_container(
 
             let total_bytes_used = padding + 4 + first_elem_padding + bytes_in_array as usize;
             if elem_sig.bytes_always_valid() {
+                // bytes_always_valid() only returns true for types whose
+                // length is equal to their alignment
                 if bytes_in_array as usize % elem_sig.get_alignment() != 0 {
+                    // there is not a whole number of elements in the array.
                     return Err((offset, Error::NotEnoughBytes));
                 }
             } else {


### PR DESCRIPTION
When validating integer types and doubles, any bit-pattern is valid. When validating an array of just these types, you can skip validating each element individually.

This improves the runtime of validating arrays of these always-valid-types from O(n) to O(1).

Also a bug was fixed in validating arrays that allowed for the last element to overflow the array.