### PR TITLE
Make MessageBuilder methods generic

### DIFF
--- a/example_keywallet/src/bin/client/main.rs
+++ b/example_keywallet/src/bin/client/main.rs
@@ -19,10 +19,10 @@ fn main() {
 
     let mut rpc_conn = rustbus::connection::rpc_conn::RpcConn::new(con);
     let mut msg = rustbus::message_builder::MessageBuilder::new()
-        .call("SearchItems".into())
-        .on("/org/freedesktop/secrets".into())
-        .with_interface("org.freedesktop.Secret.Service".into())
-        .at("io.killingspark.secrets".into())
+        .call("SearchItems")
+        .on("/org/freedesktop/secrets")
+        .with_interface("org.freedesktop.Secret.Service")
+        .at("io.killingspark.secrets")
         .build();
 
     let attrs = std::collections::HashMap::<String, String>::new();

--- a/example_keywallet/src/bin/service/main.rs
+++ b/example_keywallet/src/bin/service/main.rs
@@ -210,7 +210,7 @@ fn main() {
 
     con.send
         .send_message(&rustbus::standard_messages::request_name(
-            "io.killingspark.secrets".into(),
+            "io.killingspark.secrets",
             rustbus::standard_messages::DBUS_NAME_FLAG_REPLACE_EXISTING,
         ))
         .unwrap()

--- a/rustbus/examples/deriving.rs
+++ b/rustbus/examples/deriving.rs
@@ -55,9 +55,9 @@ fn main() {
     // create a signal with the MessageBuilder API
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 

--- a/rustbus/examples/deriving.rs
+++ b/rustbus/examples/deriving.rs
@@ -54,11 +54,7 @@ fn main() {
 
     // create a signal with the MessageBuilder API
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     // add a parameter to the signal

--- a/rustbus/examples/dispatch.rs
+++ b/rustbus/examples/dispatch.rs
@@ -103,9 +103,9 @@ fn main() {
 
         // default handler
         let mut msg1 = rustbus::message_builder::MessageBuilder::new()
-            .call("ABCD".into())
-            .at("killing.spark.io".into())
-            .on("/ABCD".into())
+            .call("ABCD")
+            .at("killing.spark.io")
+            .on("/ABCD")
             .build();
         con.send
             .send_message(&mut msg1)
@@ -115,9 +115,9 @@ fn main() {
 
         // pick up the name
         let mut msg2 = rustbus::message_builder::MessageBuilder::new()
-            .call("ABCD".into())
-            .at("killing.spark.io".into())
-            .on("/A/B/moritz".into())
+            .call("ABCD")
+            .at("killing.spark.io")
+            .on("/A/B/moritz")
             .build();
         con.send
             .send_message(&mut msg2)
@@ -127,9 +127,9 @@ fn main() {
 
         // call new handler for that name
         let mut msg3 = rustbus::message_builder::MessageBuilder::new()
-            .call("ABCD".into())
-            .at("killing.spark.io".into())
-            .on("/moritz".into())
+            .call("ABCD")
+            .at("killing.spark.io")
+            .on("/moritz")
             .build();
         con.send
             .send_message(&mut msg3)

--- a/rustbus/examples/fd.rs
+++ b/rustbus/examples/fd.rs
@@ -60,9 +60,9 @@ fn send_fd() -> Result<(), rustbus::connection::Error> {
     con.send_hello(Timeout::Infinite).unwrap();
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 
@@ -74,9 +74,9 @@ fn send_fd() -> Result<(), rustbus::connection::Error> {
 
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
     con.send.send_message(&mut sig)?.write_all().unwrap();

--- a/rustbus/examples/fd.rs
+++ b/rustbus/examples/fd.rs
@@ -59,11 +59,7 @@ fn send_fd() -> Result<(), rustbus::connection::Error> {
     let mut con = rustbus::DuplexConn::connect_to_bus(session_path, true)?;
     con.send_hello(Timeout::Infinite).unwrap();
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     use std::os::unix::io::AsRawFd;
@@ -73,11 +69,7 @@ fn send_fd() -> Result<(), rustbus::connection::Error> {
     con.send.send_message(&mut sig)?.write_all().unwrap();
 
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
     con.send.send_message(&mut sig)?.write_all().unwrap();
 

--- a/rustbus/examples/sig.rs
+++ b/rustbus/examples/sig.rs
@@ -7,9 +7,9 @@ fn main() -> Result<(), rustbus::connection::Error> {
 
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 

--- a/rustbus/examples/sig.rs
+++ b/rustbus/examples/sig.rs
@@ -6,11 +6,7 @@ fn main() -> Result<(), rustbus::connection::Error> {
     con.send_hello(Timeout::Infinite)?;
 
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     let mut dict1 = std::collections::HashMap::new();

--- a/rustbus/examples/systemd_example.rs
+++ b/rustbus/examples/systemd_example.rs
@@ -14,10 +14,10 @@ const SD1_PATH: &str = "/org/freedesktop/systemd1";
 
 fn systemd_sd1_call(method: &str) -> MarshalledMessage {
     message_builder::MessageBuilder::new()
-        .call(method.into())
-        .with_interface("org.freedesktop.systemd1.Manager".into())
-        .on(SD1_PATH.into())
-        .at(SD1_DST.into())
+        .call(method)
+        .with_interface("org.freedesktop.systemd1.Manager")
+        .on(SD1_PATH)
+        .at(SD1_DST)
         .build()
 }
 

--- a/rustbus/examples/user_defined_types.rs
+++ b/rustbus/examples/user_defined_types.rs
@@ -131,11 +131,7 @@ fn main() -> Result<(), rustbus::connection::Error> {
     con.send_hello(Timeout::Infinite)?;
 
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     let t = MyType {

--- a/rustbus/examples/user_defined_types.rs
+++ b/rustbus/examples/user_defined_types.rs
@@ -132,9 +132,9 @@ fn main() -> Result<(), rustbus::connection::Error> {
 
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 

--- a/rustbus/src/bin/create_corpus.rs
+++ b/rustbus/src/bin/create_corpus.rs
@@ -51,10 +51,10 @@ fn make_and_dump<P1: Marshal, P2: Marshal>(path: &str, p1: P1, p2: P2) {
 // creating multiple message headers
 fn make_message() -> MarshalledMessage {
     MessageBuilder::new()
-        .call("ABCD".into())
-        .on("/A/B/C".into())
-        .with_interface("ABCD.ABCD".into())
-        .at("ABCD.ABCD".into())
+        .call("ABCD")
+        .on("/A/B/C")
+        .with_interface("ABCD.ABCD")
+        .at("ABCD.ABCD")
         .build()
 }
 

--- a/rustbus/src/connection/dispatch_conn.rs
+++ b/rustbus/src/connection/dispatch_conn.rs
@@ -141,14 +141,15 @@ pub enum HandleError<UserError: std::fmt::Debug> {
     Connection(crate::connection::Error),
     User(UserError),
 }
-impl<UserError: std::fmt::Debug> Into<HandleError<UserError>> for crate::Error {
-    fn into(self) -> HandleError<UserError> {
-        HandleError::Rustbus(self)
+impl<UserError: std::fmt::Debug> From<crate::Error> for HandleError<UserError> {
+    fn from(err: crate::Error) -> Self {
+        HandleError::Rustbus(err)
     }
 }
-impl<UserError: std::fmt::Debug> Into<HandleError<UserError>> for crate::connection::Error {
-    fn into(self) -> HandleError<UserError> {
-        HandleError::Connection(self)
+
+impl<UserError: std::fmt::Debug> From<crate::connection::Error> for HandleError<UserError> {
+    fn from(err: crate::connection::Error) -> Self {
+        HandleError::Connection(err)
     }
 }
 

--- a/rustbus/src/lib.rs
+++ b/rustbus/src/lib.rs
@@ -14,9 +14,9 @@
 //!     // Next you will probably want to create a new message to send out to the world
 //!     let mut sig = MessageBuilder::new()
 //!         .signal(
-//!             "io.killing.spark".into(),
-//!             "TestSignal".into(),
-//!             "/io/killing/spark".into(),
+//!             "io.killing.spark",
+//!             "TestSignal",
+//!             "/io/killing/spark",
 //!         )
 //!         .build();
 //!     

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -72,10 +72,10 @@ pub struct DynamicHeader {
 
 impl DynamicHeader {
     /// Make a correctly addressed error response with the correct response serial
-    pub fn make_error_response(
+    pub fn make_error_response<S: Into<String>, O: Into<String>>(
         &self,
-        error_name: String,
-        error_msg: Option<String>,
+        error_name: S,
+        error_msg: Option<O>,
     ) -> crate::message_builder::MarshalledMessage {
         let mut err_resp = crate::message_builder::MarshalledMessage {
             typ: MessageType::Reply,
@@ -89,13 +89,13 @@ impl DynamicHeader {
                 sender: None,
                 signature: None,
                 response_serial: self.serial,
-                error_name: Some(error_name),
+                error_name: Some(error_name.into()),
             },
             flags: 0,
             body: crate::message_builder::MarshalledMessageBody::new(),
         };
         if let Some(text) = error_msg {
-            err_resp.body.push_param(text).unwrap();
+            err_resp.body.push_param(text.into()).unwrap();
         }
         err_resp
     }
@@ -152,33 +152,38 @@ impl MessageBuilder {
         }
     }
 
-    pub fn call(mut self, member: String) -> CallBuilder {
+    pub fn call<S: Into<String>>(mut self, member: S) -> CallBuilder {
         self.msg.typ = MessageType::Call;
-        self.msg.dynheader.member = Some(member);
+        self.msg.dynheader.member = Some(member.into());
         CallBuilder { msg: self.msg }
     }
-    pub fn signal(mut self, interface: String, member: String, object: String) -> SignalBuilder {
+    pub fn signal<S1, S2, S3>(mut self, interface: S1, member: S2, object: S3) -> SignalBuilder 
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+        S3: Into<String>,
+    {
         self.msg.typ = MessageType::Signal;
-        self.msg.dynheader.member = Some(member);
-        self.msg.dynheader.interface = Some(interface);
-        self.msg.dynheader.object = Some(object);
+        self.msg.dynheader.member = Some(member.into());
+        self.msg.dynheader.interface = Some(interface.into());
+        self.msg.dynheader.object = Some(object.into());
         SignalBuilder { msg: self.msg }
     }
 }
 
 impl CallBuilder {
-    pub fn on(mut self, object_path: String) -> Self {
-        self.msg.dynheader.object = Some(object_path);
+    pub fn on<S: Into<String>>(mut self, object_path: S) -> Self {
+        self.msg.dynheader.object = Some(object_path.into());
         self
     }
 
-    pub fn with_interface(mut self, interface: String) -> Self {
-        self.msg.dynheader.interface = Some(interface);
+    pub fn with_interface<S: Into<String>>(mut self, interface: S) -> Self {
+        self.msg.dynheader.interface = Some(interface.into());
         self
     }
 
-    pub fn at(mut self, destination: String) -> Self {
-        self.msg.dynheader.destination = Some(destination);
+    pub fn at<S: Into<String>>(mut self, destination: S) -> Self {
+        self.msg.dynheader.destination = Some(destination.into());
         self
     }
 

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -193,8 +193,8 @@ impl CallBuilder {
 }
 
 impl SignalBuilder {
-    pub fn to(mut self, destination: String) -> Self {
-        self.msg.dynheader.destination = Some(destination);
+    pub fn to<S: Into<String>>(mut self, destination: S) -> Self {
+        self.msg.dynheader.destination = Some(destination.into());
         self
     }
 

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -72,10 +72,10 @@ pub struct DynamicHeader {
 
 impl DynamicHeader {
     /// Make a correctly addressed error response with the correct response serial
-    pub fn make_error_response<S: Into<String>, O: Into<String>>(
+    pub fn make_error_response<S: Into<String>>(
         &self,
         error_name: S,
-        error_msg: Option<O>,
+        error_msg: Option<String>,
     ) -> crate::message_builder::MarshalledMessage {
         let mut err_resp = crate::message_builder::MarshalledMessage {
             typ: MessageType::Reply,
@@ -95,7 +95,7 @@ impl DynamicHeader {
             body: crate::message_builder::MarshalledMessageBody::new(),
         };
         if let Some(text) = error_msg {
-            err_resp.body.push_param(text.into()).unwrap();
+            err_resp.body.push_param(text).unwrap();
         }
         err_resp
     }
@@ -157,7 +157,7 @@ impl MessageBuilder {
         self.msg.dynheader.member = Some(member.into());
         CallBuilder { msg: self.msg }
     }
-    pub fn signal<S1, S2, S3>(mut self, interface: S1, member: S2, object: S3) -> SignalBuilder 
+    pub fn signal<S1, S2, S3>(mut self, interface: S1, member: S2, object: S3) -> SignalBuilder
     where
         S1: Into<String>,
         S2: Into<String>,

--- a/rustbus/src/standard_messages.rs
+++ b/rustbus/src/standard_messages.rs
@@ -63,7 +63,7 @@ pub fn request_name(name: String, flags: u32) -> MarshalledMessage {
 }
 
 /// Add a match rule to receive signals. e.g. match_rule = "type='signal'" to get all signals
-pub fn add_match(match_rule: String) -> MarshalledMessage {
+pub fn add_match(match_rule: &str) -> MarshalledMessage {
     let mut msg = MessageBuilder::new()
         .call("AddMatch")
         .on("/org/freedesktop/DBus")

--- a/rustbus/src/standard_messages.rs
+++ b/rustbus/src/standard_messages.rs
@@ -5,12 +5,7 @@ use crate::message_builder::MarshalledMessage;
 use crate::message_builder::MessageBuilder;
 
 pub fn hello() -> MarshalledMessage {
-    MessageBuilder::new()
-        .call("Hello")
-        .on("/org/freedesktop/DBus")
-        .with_interface("org.freedesktop.DBus")
-        .at("org.freedesktop.DBus")
-        .build()
+    make_standard_msg("Hello")
 }
 
 pub fn ping(dest: String) -> MarshalledMessage {
@@ -31,12 +26,7 @@ pub fn ping_bus() -> MarshalledMessage {
 }
 
 pub fn list_names() -> MarshalledMessage {
-    MessageBuilder::new()
-        .call("ListNames")
-        .on("/org/freedesktop/DBus")
-        .with_interface("org.freedesktop.DBus")
-        .at("org.freedesktop.DBus")
-        .build()
+    make_standard_msg("ListNames")
 }
 
 pub const DBUS_NAME_FLAG_ALLOW_REPLACEMENT: u32 = 1;
@@ -48,33 +38,41 @@ pub const DBUS_REQUEST_NAME_REPLY_IN_QUEUE: u32 = 2;
 pub const DBUS_REQUEST_NAME_REPLY_EXISTS: u32 = 3;
 pub const DBUS_REQUEST_NAME_REPLY_ALREADY_OWNER: u32 = 4;
 
-/// Request a name on the bus
-pub fn request_name(name: String, flags: u32) -> MarshalledMessage {
-    let mut msg = MessageBuilder::new()
-        .call("RequestName")
+fn make_standard_msg(name: &str) -> MarshalledMessage {
+    MessageBuilder::new()
+        .call(name)
         .on("/org/freedesktop/DBus")
         .with_interface("org.freedesktop.DBus")
         .at("org.freedesktop.DBus")
-        .build();
-
-    msg.body.push_param(name.as_str()).unwrap();
+        .build()
+}
+/// Request a name on the bus
+pub fn request_name(name: &str, flags: u32) -> MarshalledMessage {
+    let mut msg = make_standard_msg("RequestName");
+    msg.body.push_param(name).unwrap();
     msg.body.push_param(flags).unwrap();
+    msg
+}
+
+/// Release a name on the bus
+pub fn release_name(name: &str) -> MarshalledMessage {
+    let mut msg = make_standard_msg("ReleaseName");
+    msg.body.push_param(name).unwrap();
     msg
 }
 
 /// Add a match rule to receive signals. e.g. match_rule = "type='signal'" to get all signals
 pub fn add_match(match_rule: &str) -> MarshalledMessage {
-    let mut msg = MessageBuilder::new()
-        .call("AddMatch")
-        .on("/org/freedesktop/DBus")
-        .with_interface("org.freedesktop.DBus")
-        .at("org.freedesktop.DBus")
-        .build();
-
+    let mut msg = make_standard_msg("AddMatch");
     msg.body.push_param(match_rule).unwrap();
     msg
 }
-
+/// Remove a match rule to receive signals. e.g. match_rule = "type='signal'" to get all signals
+pub fn remove_match(match_rule: &str) -> MarshalledMessage {
+    let mut msg = make_standard_msg("RemoveMatch");
+    msg.body.push_param(match_rule).unwrap();
+    msg
+}
 /// Error message to tell the caller that this method is not known by your server
 pub fn unknown_method(call: &DynamicHeader) -> MarshalledMessage {
     let text = format!(

--- a/rustbus/src/standard_messages.rs
+++ b/rustbus/src/standard_messages.rs
@@ -6,36 +6,36 @@ use crate::message_builder::MessageBuilder;
 
 pub fn hello() -> MarshalledMessage {
     MessageBuilder::new()
-        .call("Hello".into())
-        .on("/org/freedesktop/DBus".into())
-        .with_interface("org.freedesktop.DBus".into())
-        .at("org.freedesktop.DBus".into())
+        .call("Hello")
+        .on("/org/freedesktop/DBus")
+        .with_interface("org.freedesktop.DBus")
+        .at("org.freedesktop.DBus")
         .build()
 }
 
 pub fn ping(dest: String) -> MarshalledMessage {
     MessageBuilder::new()
-        .call("Ping".into())
-        .on("/org/freedesktop/DBus".into())
-        .with_interface("org.freedesktop.DBus.Peer".into())
+        .call("Ping")
+        .on("/org/freedesktop/DBus")
+        .with_interface("org.freedesktop.DBus.Peer")
         .at(dest)
         .build()
 }
 
 pub fn ping_bus() -> MarshalledMessage {
     MessageBuilder::new()
-        .call("Ping".into())
-        .on("/org/freedesktop/DBus".into())
-        .with_interface("org.freedesktop.DBus.Peer".into())
+        .call("Ping")
+        .on("/org/freedesktop/DBus")
+        .with_interface("org.freedesktop.DBus.Peer")
         .build()
 }
 
 pub fn list_names() -> MarshalledMessage {
     MessageBuilder::new()
-        .call("ListNames".into())
-        .on("/org/freedesktop/DBus".into())
-        .with_interface("org.freedesktop.DBus".into())
-        .at("org.freedesktop.DBus".into())
+        .call("ListNames")
+        .on("/org/freedesktop/DBus")
+        .with_interface("org.freedesktop.DBus")
+        .at("org.freedesktop.DBus")
         .build()
 }
 
@@ -51,10 +51,10 @@ pub const DBUS_REQUEST_NAME_REPLY_ALREADY_OWNER: u32 = 4;
 /// Request a name on the bus
 pub fn request_name(name: String, flags: u32) -> MarshalledMessage {
     let mut msg = MessageBuilder::new()
-        .call("RequestName".into())
-        .on("/org/freedesktop/DBus".into())
-        .with_interface("org.freedesktop.DBus".into())
-        .at("org.freedesktop.DBus".into())
+        .call("RequestName")
+        .on("/org/freedesktop/DBus")
+        .with_interface("org.freedesktop.DBus")
+        .at("org.freedesktop.DBus")
         .build();
 
     msg.body.push_param(name.as_str()).unwrap();
@@ -65,10 +65,10 @@ pub fn request_name(name: String, flags: u32) -> MarshalledMessage {
 /// Add a match rule to receive signals. e.g. match_rule = "type='signal'" to get all signals
 pub fn add_match(match_rule: String) -> MarshalledMessage {
     let mut msg = MessageBuilder::new()
-        .call("AddMatch".into())
-        .on("/org/freedesktop/DBus".into())
-        .with_interface("org.freedesktop.DBus".into())
-        .at("org.freedesktop.DBus".into())
+        .call("AddMatch")
+        .on("/org/freedesktop/DBus")
+        .with_interface("org.freedesktop.DBus")
+        .at("org.freedesktop.DBus")
         .build();
 
     msg.body.push_param(match_rule).unwrap();

--- a/rustbus/src/tests/fdpassing.rs
+++ b/rustbus/src/tests/fdpassing.rs
@@ -70,11 +70,7 @@ fn send_fd(
     fd: crate::wire::UnixFd,
 ) -> Result<(), connection::Error> {
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     sig.dynheader.num_fds = Some(1);
@@ -89,11 +85,7 @@ fn send_fd(
         .unwrap();
 
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
     con.send_message(&mut sig)?
         .write_all()
@@ -111,11 +103,7 @@ fn test_fd_marshalling() {
     let test_fd3: UnixFd = UnixFd::new(nix::unistd::dup(1).unwrap());
 
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     sig.body

--- a/rustbus/src/tests/fdpassing.rs
+++ b/rustbus/src/tests/fdpassing.rs
@@ -71,9 +71,9 @@ fn send_fd(
 ) -> Result<(), connection::Error> {
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 
@@ -90,9 +90,9 @@ fn send_fd(
 
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
     con.send_message(&mut sig)?
@@ -112,9 +112,9 @@ fn test_fd_marshalling() {
 
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 

--- a/rustbus/src/tests/mod.rs
+++ b/rustbus/src/tests/mod.rs
@@ -27,9 +27,9 @@ fn test_marshal_unmarshal() {
 
     let mut msg = crate::message_builder::MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 
@@ -65,9 +65,9 @@ fn test_invalid_stuff() {
     // invalid signature
     let mut msg = crate::message_builder::MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 
@@ -86,9 +86,9 @@ fn test_invalid_stuff() {
     // invalid objectpath
     let mut msg = crate::message_builder::MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
     let err = msg
@@ -104,9 +104,9 @@ fn test_invalid_stuff() {
     // invalid interface
     let mut msg = crate::message_builder::MessageBuilder::new()
         .signal(
-            ".......io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            ".......io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
     msg.dynheader.serial = Some(1);
@@ -121,9 +121,9 @@ fn test_invalid_stuff() {
     // invalid member
     let mut msg = crate::message_builder::MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "Members.have.no.dots".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "Members.have.no.dots",
+            "/io/killing/spark",
         )
         .build();
     msg.dynheader.serial = Some(1);

--- a/rustbus/src/tests/mod.rs
+++ b/rustbus/src/tests/mod.rs
@@ -26,11 +26,7 @@ fn test_marshal_unmarshal() {
     params.push(Base::ObjectPath("/this/object/path".into()).into());
 
     let mut msg = crate::message_builder::MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     // mixing old and new style of params and check that they are unmarshalled correctly
@@ -64,11 +60,7 @@ fn test_marshal_unmarshal() {
 fn test_invalid_stuff() {
     // invalid signature
     let mut msg = crate::message_builder::MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     let err = msg
@@ -85,11 +77,7 @@ fn test_invalid_stuff() {
 
     // invalid objectpath
     let mut msg = crate::message_builder::MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
     let err = msg
         .body
@@ -103,11 +91,7 @@ fn test_invalid_stuff() {
 
     // invalid interface
     let mut msg = crate::message_builder::MessageBuilder::new()
-        .signal(
-            ".......io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal(".......io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
     msg.dynheader.serial = Some(1);
     let mut buf = Vec::new();

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -156,7 +156,7 @@ fn test_generic_unmarshal() {
 
     // No type info on let arg = unmarshal(...) is needed if it can be derived by other means
     ctx.buf.clear();
-    fn x(_arg: (i32, i32, &str)) {};
+    fn x(_arg: (i32, i32, &str)) {}
     (0, 0, "ABCD").marshal(ctx).unwrap();
     let arg = unmarshal(&mut UnmarshalContext {
         buf: &ctx.buf,

--- a/rustbus_derive_test/src/lib.rs
+++ b/rustbus_derive_test/src/lib.rs
@@ -55,9 +55,9 @@ fn test_derive() {
     // create a signal with the MessageBuilder API
     let mut sig = MessageBuilder::new()
         .signal(
-            "io.killing.spark".into(),
-            "TestSignal".into(),
-            "/io/killing/spark".into(),
+            "io.killing.spark",
+            "TestSignal",
+            "/io/killing/spark",
         )
         .build();
 

--- a/rustbus_derive_test/src/lib.rs
+++ b/rustbus_derive_test/src/lib.rs
@@ -54,11 +54,7 @@ fn test_derive() {
 
     // create a signal with the MessageBuilder API
     let mut sig = MessageBuilder::new()
-        .signal(
-            "io.killing.spark",
-            "TestSignal",
-            "/io/killing/spark",
-        )
+        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
 
     // add a parameter to the signal


### PR DESCRIPTION
In my experience when building messages, you are almost always working with string slices when filling out the fields of a message because interface names, method names, and often destinations tend to be well defined ahead of time. 
The creates a common pattern where you write something like this using `String::into()`/`to_string()`/`to_owned()` for the vast majority of calls:
```rust
    let mut msg = rustbus::message_builder::MessageBuilder::new()
        .call("SearchItems".into())
        .on("/org/freedesktop/secrets".into())
        .with_interface("org.freedesktop.Secret.Service".into())
        .at("io.killingspark.secrets".into())
        .build();
    let mut sig = MessageBuilder::new()
        .signal(
            "io.killing.spark".into(),
            "TestSignal".into(),
            "/io/killing/spark".into(),
        )
```
This pattern exists all through out the crate's examples and also shows up in real world patterns. By making the inputs generic over `<S: Into<String>>` this pattern can be eliminated often resulting in cleaner, shorter code. An example from this crate 
```rust
let mut sig = MessageBuilder::new()
        .signal(
            "io.killing.spark".into(),
            "TestSignal".into(),
            "/io/killing/spark".into(),
        )
        .build()
  ///  seven lines becomes three
  let mut sig = MessageBuilder::new()
        .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
        .build()
```

Unfortunately, it is a breaking API change because it breaks type inference for people using `String::into()` to build the string. 
