### PR TITLE
Improvements to variant macros

### DIFF
--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -739,9 +739,7 @@ impl<'ret, 'fds, 'body: 'ret + 'fds> MessageBodyParser<'body> {
 
     /// Get the next param, use get::<TYPE> to specify what type you expect. For example `let s = parser.get::<String>()?;`
     /// This checks if there are params left in the message and if the type you requested fits the signature of the message.
-    pub fn get<T: Unmarshal<'ret, 'body, 'fds>>(
-        &mut self,
-    ) -> Result<T, crate::wire::unmarshal::Error> {
+    pub fn get<T: Unmarshal<'body, 'fds>>(&mut self) -> Result<T, crate::wire::unmarshal::Error> {
         if self.sig_idx >= self.sigs.len() {
             return Err(crate::wire::unmarshal::Error::EndOfMessage);
         }
@@ -792,8 +790,8 @@ impl<'ret, 'fds, 'body: 'ret + 'fds> MessageBodyParser<'body> {
     /// This checks if there are params left in the message and if the type you requested fits the signature of the message.
     pub fn get2<T1, T2>(&mut self) -> Result<(T1, T2), crate::wire::unmarshal::Error>
     where
-        T1: Unmarshal<'ret, 'body, 'fds>,
-        T2: Unmarshal<'ret, 'body, 'fds>,
+        T1: Unmarshal<'body, 'fds>,
+        T2: Unmarshal<'body, 'fds>,
     {
         let get_calls = |parser: &mut Self| {
             let ret1 = parser.get()?;
@@ -807,9 +805,9 @@ impl<'ret, 'fds, 'body: 'ret + 'fds> MessageBodyParser<'body> {
     /// This checks if there are params left in the message and if the type you requested fits the signature of the message.
     pub fn get3<T1, T2, T3>(&mut self) -> Result<(T1, T2, T3), crate::wire::unmarshal::Error>
     where
-        T1: Unmarshal<'ret, 'body, 'fds>,
-        T2: Unmarshal<'ret, 'body, 'fds>,
-        T3: Unmarshal<'ret, 'body, 'fds>,
+        T1: Unmarshal<'body, 'fds>,
+        T2: Unmarshal<'body, 'fds>,
+        T3: Unmarshal<'body, 'fds>,
     {
         let get_calls = |parser: &mut Self| {
             let ret1 = parser.get()?;
@@ -826,10 +824,10 @@ impl<'ret, 'fds, 'body: 'ret + 'fds> MessageBodyParser<'body> {
         &mut self,
     ) -> Result<(T1, T2, T3, T4), crate::wire::unmarshal::Error>
     where
-        T1: Unmarshal<'ret, 'body, 'fds>,
-        T2: Unmarshal<'ret, 'body, 'fds>,
-        T3: Unmarshal<'ret, 'body, 'fds>,
-        T4: Unmarshal<'ret, 'body, 'fds>,
+        T1: Unmarshal<'body, 'fds>,
+        T2: Unmarshal<'body, 'fds>,
+        T3: Unmarshal<'body, 'fds>,
+        T4: Unmarshal<'body, 'fds>,
     {
         let get_calls = |parser: &mut Self| {
             let ret1 = parser.get()?;
@@ -847,11 +845,11 @@ impl<'ret, 'fds, 'body: 'ret + 'fds> MessageBodyParser<'body> {
         &mut self,
     ) -> Result<(T1, T2, T3, T4, T5), crate::wire::unmarshal::Error>
     where
-        T1: Unmarshal<'ret, 'body, 'fds>,
-        T2: Unmarshal<'ret, 'body, 'fds>,
-        T3: Unmarshal<'ret, 'body, 'fds>,
-        T4: Unmarshal<'ret, 'body, 'fds>,
-        T5: Unmarshal<'ret, 'body, 'fds>,
+        T1: Unmarshal<'body, 'fds>,
+        T2: Unmarshal<'body, 'fds>,
+        T3: Unmarshal<'body, 'fds>,
+        T4: Unmarshal<'body, 'fds>,
+        T5: Unmarshal<'body, 'fds>,
     {
         let get_calls = |parser: &mut Self| {
             let ret1 = parser.get()?;

--- a/rustbus/src/wire/unixfd.rs
+++ b/rustbus/src/wire/unixfd.rs
@@ -170,7 +170,7 @@ impl Marshal for &dyn std::os::unix::io::AsRawFd {
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for UnixFd {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for UnixFd {
     fn unmarshal(
         ctx: &mut UnmarshalContext<'fds, 'buf>,
     ) -> crate::wire::unmarshal::UnmarshalResult<Self> {

--- a/rustbus/src/wire/unmarshal/iter.rs
+++ b/rustbus/src/wire/unmarshal/iter.rs
@@ -49,12 +49,7 @@ impl<'a> MessageIter<'a> {
         }
     }
 
-    pub fn unmarshal_next<
-        'r,
-        'buf: 'r,
-        'fds,
-        T: crate::wire::unmarshal::traits::Unmarshal<'r, 'buf, 'fds>,
-    >(
+    pub fn unmarshal_next<'buf, 'fds, T: crate::wire::unmarshal::traits::Unmarshal<'buf, 'fds>>(
         &'buf mut self,
     ) -> Option<Result<T, Error>> {
         if self.counter >= self.sig.len() {

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -45,7 +45,7 @@ use crate::ByteOrder;
 /// use rustbus::wire::unmarshal::UnmarshalResult;
 /// use rustbus::wire::util;
 /// use rustbus::ByteOrder;
-/// impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for MyStruct {
+/// impl<'buf, 'fds> Unmarshal<'buf, 'fds> for MyStruct {
 ///    fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
 ///         let start_offset = ctx.offset;
 ///         // check that we are aligned properly!
@@ -95,11 +95,11 @@ use crate::ByteOrder;
 /// }
 /// ```
 
-pub trait Unmarshal<'r, 'buf: 'r, 'fds>: Sized + Signature {
+pub trait Unmarshal<'buf, 'fds>: Sized + Signature {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self>;
 }
 
-pub fn unmarshal<'r, 'buf: 'r, 'fds, T: Unmarshal<'r, 'buf, 'fds>>(
+pub fn unmarshal<'buf, 'fds, T: Unmarshal<'buf, 'fds>>(
     ctx: &mut UnmarshalContext<'fds, 'buf>,
 ) -> unmarshal::UnmarshalResult<T> {
     T::unmarshal(ctx)
@@ -169,9 +169,9 @@ fn test_generic_unmarshal() {
     x(arg);
 }
 
-impl<'r, 'buf: 'r, 'fds, E1> Unmarshal<'r, 'buf, 'fds> for (E1,)
+impl<'buf, 'fds, E1> Unmarshal<'buf, 'fds> for (E1,)
 where
-    E1: Unmarshal<'r, 'buf, 'fds> + Sized,
+    E1: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(8)?;
@@ -180,10 +180,10 @@ where
     }
 }
 
-impl<'r, 'buf: 'r, 'fds, E1, E2> Unmarshal<'r, 'buf, 'fds> for (E1, E2)
+impl<'buf, 'fds, E1, E2> Unmarshal<'buf, 'fds> for (E1, E2)
 where
-    E1: Unmarshal<'r, 'buf, 'fds> + Sized,
-    E2: Unmarshal<'r, 'buf, 'fds> + Sized,
+    E1: Unmarshal<'buf, 'fds> + Sized,
+    E2: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let start_offset = ctx.offset;
@@ -198,11 +198,11 @@ where
     }
 }
 
-impl<'r, 'buf: 'r, 'fds, E1, E2, E3> Unmarshal<'r, 'buf, 'fds> for (E1, E2, E3)
+impl<'buf, 'fds, E1, E2, E3> Unmarshal<'buf, 'fds> for (E1, E2, E3)
 where
-    E1: Unmarshal<'r, 'buf, 'fds> + Sized,
-    E2: Unmarshal<'r, 'buf, 'fds> + Sized,
-    E3: Unmarshal<'r, 'buf, 'fds> + Sized,
+    E1: Unmarshal<'buf, 'fds> + Sized,
+    E2: Unmarshal<'buf, 'fds> + Sized,
+    E3: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let start_offset = ctx.offset;
@@ -221,12 +221,12 @@ where
     }
 }
 
-impl<'r, 'buf: 'r, 'fds, E1, E2, E3, E4> Unmarshal<'r, 'buf, 'fds> for (E1, E2, E3, E4)
+impl<'buf, 'fds, E1, E2, E3, E4> Unmarshal<'buf, 'fds> for (E1, E2, E3, E4)
 where
-    E1: Unmarshal<'r, 'buf, 'fds> + Sized,
-    E2: Unmarshal<'r, 'buf, 'fds> + Sized,
-    E3: Unmarshal<'r, 'buf, 'fds> + Sized,
-    E4: Unmarshal<'r, 'buf, 'fds> + Sized,
+    E1: Unmarshal<'buf, 'fds> + Sized,
+    E2: Unmarshal<'buf, 'fds> + Sized,
+    E3: Unmarshal<'buf, 'fds> + Sized,
+    E4: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let start_offset = ctx.offset;
@@ -248,7 +248,7 @@ where
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u64 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u64 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u64(&ctx.buf[ctx.offset..], ctx.byteorder)?;
@@ -256,7 +256,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u64 {
         Ok((bytes + padding, val))
     }
 }
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u32 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u32 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)?;
@@ -264,7 +264,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u32 {
         Ok((bytes + padding, val))
     }
 }
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u16 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u16 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u16(&ctx.buf[ctx.offset..], ctx.byteorder)?;
@@ -272,7 +272,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u16 {
         Ok((bytes + padding, val))
     }
 }
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for i64 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i64 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u64(&ctx.buf[ctx.offset..], ctx.byteorder)
@@ -281,7 +281,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for i64 {
         Ok((bytes + padding, val))
     }
 }
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for i32 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i32 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)
@@ -290,7 +290,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for i32 {
         Ok((bytes + padding, val))
     }
 }
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for i16 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i16 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u16(&ctx.buf[ctx.offset..], ctx.byteorder)
@@ -300,7 +300,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for i16 {
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u8 {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u8 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         if ctx.buf[ctx.offset..].is_empty() {
             return Err(crate::wire::unmarshal::Error::NotEnoughBytes);
@@ -311,7 +311,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for u8 {
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for bool {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for bool {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)?;
@@ -324,7 +324,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for bool {
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for &'r str {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf str {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::unmarshal_str(ctx.byteorder, &ctx.buf[ctx.offset..])?;
@@ -333,7 +333,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for &'r str {
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for String {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for String {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (bytes, val) = util::unmarshal_string(ctx.byteorder, &ctx.buf[ctx.offset..])?;
@@ -343,7 +343,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for String {
 }
 
 /// for byte arrays we can give an efficient method of decoding. This will bind the returned slice to the lifetime of the buffer.
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for &'r [u8] {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf [u8] {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
         let (_, bytes_in_array) = u32::unmarshal(ctx)?;
@@ -426,7 +426,7 @@ impl<E: Signature> Signature for Vec<E> {
     }
 }
 
-impl<'r, 'buf: 'r, 'fds, E: Unmarshal<'r, 'buf, 'fds>> Unmarshal<'r, 'buf, 'fds> for Vec<E> {
+impl<'buf, 'fds, E: Unmarshal<'buf, 'fds>> Unmarshal<'buf, 'fds> for Vec<E> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let start_offset = ctx.offset;
         ctx.align_to(4)?;
@@ -457,13 +457,8 @@ impl<'r, 'buf: 'r, 'fds, E: Unmarshal<'r, 'buf, 'fds>> Unmarshal<'r, 'buf, 'fds>
     }
 }
 
-impl<
-        'r,
-        'buf: 'r,
-        'fds,
-        K: Unmarshal<'r, 'buf, 'fds> + std::hash::Hash + Eq,
-        V: Unmarshal<'r, 'buf, 'fds>,
-    > Unmarshal<'r, 'buf, 'fds> for std::collections::HashMap<K, V>
+impl<'buf, 'fds, K: Unmarshal<'buf, 'fds> + std::hash::Hash + Eq, V: Unmarshal<'buf, 'fds>>
+    Unmarshal<'buf, 'fds> for std::collections::HashMap<K, V>
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let start_offset = ctx.offset;
@@ -503,9 +498,7 @@ impl<
     }
 }
 
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds>
-    for crate::wire::marshal::traits::SignatureWrapper<'r>
-{
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for crate::wire::marshal::traits::SignatureWrapper<'buf> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         // No alignment needed. Signature is aligned to 1
         let (bytes, val) = util::unmarshal_signature(&ctx.buf[ctx.offset..])?;
@@ -514,7 +507,7 @@ impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds>
         Ok((bytes, sig))
     }
 }
-impl<'r, 'buf: 'r, 'fds, S: AsRef<str> + Unmarshal<'r, 'buf, 'fds>> Unmarshal<'r, 'buf, 'fds>
+impl<'buf, 'fds, S: AsRef<str> + Unmarshal<'buf, 'fds>> Unmarshal<'buf, 'fds>
     for crate::wire::marshal::traits::ObjectPath<S>
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
@@ -532,7 +525,7 @@ pub struct Variant<'fds, 'buf> {
     pub(crate) buf: &'buf [u8],
     pub(crate) fds: &'fds [crate::wire::UnixFd],
 }
-impl<'r, 'buf: 'r, 'fds> Variant<'fds, 'buf> {
+impl<'buf, 'fds> Variant<'fds, 'buf> {
     /// Get the [`Type`] of the value contained by the variant.
     ///
     /// [`Type`]: /rustbus/signature/enum.Type.html
@@ -543,7 +536,7 @@ impl<'r, 'buf: 'r, 'fds> Variant<'fds, 'buf> {
     /// Unmarshal the variant's value. This method is used in the same way as [`MessageBodyParser::get()`].
     ///
     /// [`MessageBodyParser::get()`]: /rustbus/message_builder/struct.MessageBodyParser.html#method.get
-    pub fn get<T: Unmarshal<'r, 'buf, 'fds>>(&self) -> Result<T, unmarshal::Error> {
+    pub fn get<T: Unmarshal<'buf, 'fds>>(&self) -> Result<T, unmarshal::Error> {
         if self.sig != T::signature() {
             return Err(unmarshal::Error::WrongSignature);
         }
@@ -564,7 +557,7 @@ impl Signature for Variant<'_, '_> {
         Variant::signature().get_alignment()
     }
 }
-impl<'r, 'buf: 'r, 'fds> Unmarshal<'r, 'buf, 'fds> for Variant<'fds, 'buf> {
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for Variant<'fds, 'buf> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let start_offset = ctx.offset;
         let (sig_bytes, desc) = util::unmarshal_signature(&ctx.buf[ctx.offset..])?;

--- a/rustbus/src/wire/variant_macros.rs
+++ b/rustbus/src/wire/variant_macros.rs
@@ -282,7 +282,7 @@ fn test_variant_sig_macro() {
 ///     * `type StrRef<'buf> = &'buf str;`
 ///     * `dbus_variant_var!(MyVariant, String => StrRef<'buf>; V2 => i32; Integer => u32);`
 macro_rules! dbus_variant_var {
-    ($vname: ident, $($name: ident => $typ: path);+) => {
+    ($vname: ident, $($name: ident => $typ: ty);+) => {
         dbus_variant_var_type!($vname, $(
             $name => $typ
         )+);
@@ -308,7 +308,7 @@ macro_rules! dbus_variant_var {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dbus_variant_var_type {
-    ($vname: ident, $($name: ident => $typ: path)+) => {
+    ($vname: ident, $($name: ident => $typ: ty)+) => {
         #[derive(Debug)]
         pub enum $vname <'fds, 'buf> {
             $(
@@ -322,7 +322,7 @@ macro_rules! dbus_variant_var_type {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dbus_variant_var_marshal {
-    ($vname: ident, $($name: ident => $typ: path)+) => {
+    ($vname: ident, $($name: ident => $typ: ty)+) => {
         impl<'fds, 'buf> $crate::Marshal for $vname <'fds, 'buf> {
             fn marshal(&self, ctx: &mut $crate::wire::marshal::MarshalContext) -> Result<(), $crate::Error> {
                 use $crate::Signature;
@@ -351,7 +351,7 @@ macro_rules! dbus_variant_var_marshal {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dbus_variant_var_unmarshal {
-    ($vname: ident, $($name: ident => $typ: path)+) => {
+    ($vname: ident, $($name: ident => $typ: ty)+) => {
         impl<'buf, 'fds> $crate::Unmarshal<'buf,'fds> for $vname <'fds, 'buf> {
             fn unmarshal(
                 ctx: &mut $crate::wire::unmarshal::UnmarshalContext<'fds, 'buf>

--- a/rustbus/src/wire/variant_macros.rs
+++ b/rustbus/src/wire/variant_macros.rs
@@ -398,16 +398,14 @@ fn test_variant_var_macro() {
     };
     let ctx = &mut ctx;
 
-    // so the macro is able to use rustbus, like it would have to when importet into other crates
-
     type StrRef<'buf> = &'buf str;
     // The point of the Path variant is to make sure types from other modules can be used. Do NOT change it to use a use-statement.
-    dbus_variant_var!(MyVariant, String => StrRef<'buf>; V2 => i32; Integer => u32; Path => rustbus::wire::marshal::traits::ObjectPath<&'buf str>);
+    dbus_variant_var!(MyVariant, String => StrRef<'buf>; V2 => i32; Integer => u32; Path => crate::wire::marshal::traits::ObjectPath<&'buf str>);
     let v1 = MyVariant::String("ABCD");
     let v2 = MyVariant::V2(0);
     let v3 = MyVariant::Integer(100);
     let object_path =
-        rustbus::wire::marshal::traits::ObjectPath::new("/org/freedesktop/DBus").unwrap();
+        crate::wire::marshal::traits::ObjectPath::new("/org/freedesktop/DBus").unwrap();
     let v4 = MyVariant::Path(object_path);
 
     (&v1, &v2, &v3, &v4).marshal(ctx).unwrap();

--- a/rustbus/src/wire/variant_macros.rs
+++ b/rustbus/src/wire/variant_macros.rs
@@ -90,7 +90,7 @@ macro_rules! dbus_variant_sig_marshal {
 #[macro_export]
 macro_rules! dbus_variant_sig_unmarshal {
     ($vname: ident, $($name: ident => $typ: path)+) => {
-        impl<'ret, 'buf: 'ret, 'fds> rustbus::Unmarshal<'ret, 'buf, 'fds> for $vname {
+        impl<'buf, 'fds> rustbus::Unmarshal<'buf, 'fds> for $vname {
             fn unmarshal(
                 ctx: &mut rustbus::wire::unmarshal::UnmarshalContext<'fds, 'buf>,
             ) -> rustbus::wire::unmarshal::UnmarshalResult<Self> {
@@ -353,7 +353,7 @@ macro_rules! dbus_variant_var_marshal {
 #[macro_export]
 macro_rules! dbus_variant_var_unmarshal {
     ($vname: ident, $($name: ident => $typ: path)+) => {
-        impl<'ret, 'buf: 'ret, 'fds> rustbus::Unmarshal<'ret, 'buf,'fds> for $vname <'fds, 'ret> {
+        impl<'buf, 'fds> rustbus::Unmarshal<'buf,'fds> for $vname <'fds, 'buf> {
             fn unmarshal(
                 ctx: &mut rustbus::wire::unmarshal::UnmarshalContext<'fds, 'buf>
             ) -> rustbus::wire::unmarshal::UnmarshalResult<Self> {


### PR DESCRIPTION
First, the rustbus references within the macros where changed to use `$crate` instead. This allows the macro to be used in context where the rustbus crate isn't in scope (primarily if re-exporting).

Second, the `dbus_variant_var!` accepts types rather than paths. This allows for the users to directly use reference types in the macro without having to do an extra type def.