### PR TITLE
Misc performance improvements

### DIFF
--- a/rustbus/src/params/validation.rs
+++ b/rustbus/src/params/validation.rs
@@ -50,61 +50,52 @@ pub fn validate_object_path(op: &str) -> Result<()> {
     Ok(())
 }
 pub fn validate_interface(int: &str) -> Result<()> {
-    if int.len() < 3 {
-        return Err(Error::InvalidInterface);
-    }
-    if !int.contains('.') {
-        return Err(Error::InvalidInterface);
-    }
-
-    let split = int.split('.').collect::<Vec<_>>();
-    if split.len() < 2 {
-        return Err(Error::InvalidInterface);
-    }
-    for element in split {
-        if element.is_empty() {
-            return Err(Error::InvalidInterface);
-        }
-        if let Some(true) = element.chars().next().map(|c| c.is_numeric()) {
+    let split = int.split('.');
+    let mut cnt = 0;
+    for (i, element) in split.enumerate() {
+        if element
+            .chars()
+            .next()
+            .ok_or(Error::InvalidInterface)?
+            .is_numeric()
+        {
             return Err(Error::InvalidInterface);
         }
         let alphanum_or_underscore = element.chars().all(|c| c.is_alphanumeric() || c == '_');
         if !alphanum_or_underscore {
             return Err(Error::InvalidInterface);
         }
+        cnt = i + 1;
     }
-
-    Ok(())
+    if cnt >= 2 {
+        Ok(())
+    } else {
+        Err(Error::InvalidInterface)
+    }
 }
 
+#[inline]
 pub fn validate_errorname(en: &str) -> Result<()> {
     validate_interface(en).map_err(|_| Error::InvalidErrorname)
 }
 
 pub fn validate_busname(bn: &str) -> Result<()> {
-    if bn.len() < 3 {
-        return Err(Error::InvalidBusname);
-    }
-    if !bn.contains('.') {
-        return Err(Error::InvalidBusname);
-    }
-
     let (unique, bus_name) = if let Some(unique_name) = bn.strip_prefix(':') {
         (true, unique_name)
     } else {
         (false, bn)
     };
 
-    let split = bus_name.split('.').collect::<Vec<_>>();
-    if split.len() < 2 {
-        return Err(Error::InvalidBusname);
-    }
-
-    for element in split {
-        if element.is_empty() {
-            return Err(Error::InvalidBusname);
-        }
-        if !unique && element.chars().next().map(|c| c.is_numeric()) == Some(true) {
+    let split = bus_name.split('.');
+    let mut cnt = 0;
+    for (i, element) in split.enumerate() {
+        if element
+            .chars()
+            .next()
+            .ok_or(Error::InvalidBusname)?
+            .is_numeric()
+            && !unique
+        {
             return Err(Error::InvalidBusname);
         }
         let alphanum_or_underscore_or_dash = element
@@ -113,9 +104,13 @@ pub fn validate_busname(bn: &str) -> Result<()> {
         if !alphanum_or_underscore_or_dash {
             return Err(Error::InvalidBusname);
         }
+        cnt = i + 1;
     }
-
-    Ok(())
+    if cnt >= 2 {
+        Ok(())
+    } else {
+        Err(Error::InvalidBusname)
+    }
 }
 
 pub fn validate_membername(mem: &str) -> Result<()> {

--- a/rustbus/src/wire/marshal/traits.rs
+++ b/rustbus/src/wire/marshal/traits.rs
@@ -490,9 +490,11 @@ impl Marshal for i64 {
 }
 
 impl Signature for u32 {
+    #[inline]
     fn signature() -> crate::signature::Type {
         crate::signature::Type::Base(crate::signature::Base::Uint32)
     }
+    #[inline]
     fn alignment() -> usize {
         Self::signature().get_alignment()
     }
@@ -554,14 +556,17 @@ impl Marshal for i16 {
 }
 
 impl Signature for u8 {
+    #[inline]
     fn signature() -> crate::signature::Type {
         crate::signature::Type::Base(crate::signature::Base::Byte)
     }
+    #[inline]
     fn alignment() -> usize {
         Self::signature().get_alignment()
     }
 }
 impl Marshal for u8 {
+    #[inline]
     fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), crate::Error> {
         ctx.buf.push(*self);
         Ok(())
@@ -569,23 +574,28 @@ impl Marshal for u8 {
 }
 
 impl Signature for bool {
+    #[inline]
     fn signature() -> crate::signature::Type {
         crate::signature::Type::Base(crate::signature::Base::Boolean)
     }
+    #[inline]
     fn alignment() -> usize {
         Self::signature().get_alignment()
     }
 }
 impl Marshal for bool {
+    #[inline]
     fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), crate::Error> {
         (*self as u32).marshal(ctx)
     }
 }
 
 impl Signature for String {
+    #[inline]
     fn signature() -> crate::signature::Type {
         crate::signature::Type::Base(crate::signature::Base::String)
     }
+    #[inline]
     fn alignment() -> usize {
         Self::signature().get_alignment()
     }
@@ -597,6 +607,7 @@ impl Marshal for String {
 }
 
 impl Signature for &str {
+    #[inline]
     fn signature() -> crate::signature::Type {
         String::signature()
     }

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -302,7 +302,7 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i16 {
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u8 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        if ctx.buf[ctx.offset..].is_empty() {
+        if ctx.offset >= ctx.buf.len() {
             return Err(crate::wire::unmarshal::Error::NotEnoughBytes);
         }
         let val = ctx.buf[ctx.offset];

--- a/rustbus/src/wire/util.rs
+++ b/rustbus/src/wire/util.rs
@@ -8,7 +8,7 @@ pub fn pad_to_align(align_to: usize, buf: &mut Vec<u8>) {
     let padding_needed = align_to - (buf.len() % align_to);
     if padding_needed != align_to {
         buf.resize(buf.len() + padding_needed, 0);
-        assert!(buf.len() % align_to == 0);
+        debug_assert!(buf.len() % align_to == 0);
     }
 }
 


### PR DESCRIPTION
1. Previously some of the params::validations methods used an unecessary `Vec` to perform their validation. This eliminates them.
2. Add some inline statements for very simple functions to help with external crates marshaling performance.
3. Simplify various marshaling functions. `marshal_base_param` is too complex to be efficiently inline which is important for marshaling loops like when using arrays. 