### PR TITLE
Add Signature::sig_str and Marshal::marshal_as_variant

### DIFF
--- a/rustbus/src/signature.rs
+++ b/rustbus/src/signature.rs
@@ -125,11 +125,7 @@ impl<I: Iterator<Item = char>> Iterator for TokenIter<I> {
     type Item = Result<Token>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(c) = self.chars.next() {
-            Some(char_to_token(c))
-        } else {
-            None
-        }
+        self.chars.next().map(char_to_token)
     }
 }
 

--- a/rustbus/src/wire/marshal/traits.rs
+++ b/rustbus/src/wire/marshal/traits.rs
@@ -500,6 +500,10 @@ impl Signature for u64 {
     fn alignment() -> usize {
         Self::signature().get_alignment()
     }
+    #[inline]
+    fn sig_str<'a>(_: &'a mut String) -> &'a str {
+        "t"
+    }
 }
 impl Marshal for u64 {
     fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), crate::Error> {
@@ -515,6 +519,10 @@ impl Signature for i64 {
     }
     fn alignment() -> usize {
         Self::signature().get_alignment()
+    }
+    #[inline]
+    fn sig_str<'a>(_: &'a mut String) -> &'a str {
+        "x"
     }
 }
 impl Marshal for i64 {
@@ -572,6 +580,10 @@ impl Signature for u16 {
     fn alignment() -> usize {
         Self::signature().get_alignment()
     }
+    #[inline]
+    fn sig_str<'a>(_: &'a mut String) -> &'a str {
+        "q"
+    }
 }
 impl Marshal for u16 {
     fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), crate::Error> {
@@ -587,6 +599,10 @@ impl Signature for i16 {
     }
     fn alignment() -> usize {
         Self::signature().get_alignment()
+    }
+    #[inline]
+    fn sig_str<'a>(_: &'a mut String) -> &'a str {
+        "n"
     }
 }
 impl Marshal for i16 {

--- a/rustbus/src/wire/marshal/traits.rs
+++ b/rustbus/src/wire/marshal/traits.rs
@@ -112,7 +112,6 @@ impl SignatureBuffer {
     /// Return a `&mut String` which can be used to modify the signature.
     ///
     /// Internally this is just a call to `Cow::to_mut`.
-    #[allow(clippy::wrong_self_convention)]
     #[inline]
     pub fn to_string_mut(&mut self) -> &mut String {
         self.0.to_mut()

--- a/rustbus/src/wire/unmarshal/mod.rs
+++ b/rustbus/src/wire/unmarshal/mod.rs
@@ -156,10 +156,10 @@ pub fn unmarshal_body<'a, 'e>(
     let mut params = Vec::new();
     let mut body_bytes_used = 0;
     let mut ctx = UnmarshalContext {
-        byteorder,
-        buf,
-        offset,
         fds,
+        buf,
+        byteorder,
+        offset,
     };
     for param_sig in sigs {
         let (bytes, new_param) = unmarshal_with_sig(&param_sig, &mut ctx)?;

--- a/rustbus/src/wire/unmarshal/mod.rs
+++ b/rustbus/src/wire/unmarshal/mod.rs
@@ -176,9 +176,9 @@ pub fn unmarshal_next_message(
     offset: usize,
 ) -> UnmarshalResult<MarshalledMessage> {
     let sig = dynheader.signature.clone().unwrap_or_else(|| "".to_owned());
+    let padding = align_offset(8, buf, offset)?;
 
     if header.body_len == 0 {
-        let padding = align_offset(8, buf, offset)?;
         let msg = MarshalledMessage {
             dynheader,
             body: MarshalledMessageBody::from_parts(vec![], vec![], sig, header.byteorder),
@@ -187,7 +187,6 @@ pub fn unmarshal_next_message(
         };
         Ok((padding, msg))
     } else {
-        let padding = align_offset(8, buf, offset)?;
         let offset = offset + padding;
 
         if buf[offset..].len() < (header.body_len as usize) {

--- a/rustbus/src/wire/variant_macros.rs
+++ b/rustbus/src/wire/variant_macros.rs
@@ -325,19 +325,10 @@ macro_rules! dbus_variant_var_marshal {
     ($vname: ident, $($name: ident => $typ: ty)+) => {
         impl<'fds, 'buf> $crate::Marshal for $vname <'fds, 'buf> {
             fn marshal(&self, ctx: &mut $crate::wire::marshal::MarshalContext) -> Result<(), $crate::Error> {
-                use $crate::Signature;
-
                 match self {
                     $(
                         Self::$name(v) => {
-                            let mut sig_str = String::new();
-                            <$typ as Signature>::signature().to_str(&mut sig_str);
-                            $crate::wire::marshal::base::marshal_base_param(
-                                &$crate::params::Base::Signature(sig_str),
-                                ctx,
-                            )
-                            .unwrap();
-                            v.marshal(ctx)?;
+							v.marshal_as_variant(ctx)?;
                         }
                     )+
                     Self::Catchall(_) => unimplemented!("Do not use Catchall for Marshal cases!"),
@@ -360,15 +351,9 @@ macro_rules! dbus_variant_var_unmarshal {
                 use $crate::Unmarshal;
 
                 let (sig_bytes, sig_str) = $crate::wire::util::unmarshal_signature(&ctx.buf[ctx.offset..])?;
-                let mut sig = $crate::signature::Type::parse_description(&sig_str)?;
-                let sig = if sig.len() == 1 {
-                    sig.remove(0)
-                } else {
-                    return Err($crate::wire::unmarshal::Error::WrongSignature);
-                };
-
+				let mut sig_buf = String::new();
                 $(
-                if sig == <$typ as Signature>::signature() {
+                if sig_str == <$typ as Signature>::sig_str(&mut sig_buf) {
                     ctx.offset += sig_bytes;
                     let (vbytes, v) = <$typ as $crate::Unmarshal>::unmarshal(ctx)?;
                     return Ok((sig_bytes + vbytes, Self::$name(v)));

--- a/rustbus/src/wire/variant_macros.rs
+++ b/rustbus/src/wire/variant_macros.rs
@@ -349,18 +349,14 @@ macro_rules! dbus_variant_var_unmarshal {
             ) -> $crate::wire::unmarshal::UnmarshalResult<Self> {
                 use $crate::Signature;
                 use $crate::Unmarshal;
-                use std::borrow::Cow;
+                use $crate::wire::marshal::traits::SignatureBuffer;
 
                 let (sig_bytes, sig_str) = $crate::wire::util::unmarshal_signature(&ctx.buf[ctx.offset..])?;
-                let mut var_sig = Cow::Borrowed("");
-                let clear = |s: &mut Cow<str>| match s {
-                    Cow::Borrowed(_) => *s = Cow::Borrowed(""),
-                    Cow::Owned(o) => o.clear()
-                };
+                let mut var_sig = SignatureBuffer::new();
                 $(
-                clear(&mut var_sig);
+                var_sig.clear();
                 <$typ as Signature>::sig_str(&mut var_sig);
-                if sig_str == var_sig {
+                if sig_str == var_sig.as_ref() {
                     ctx.offset += sig_bytes;
                     let (vbytes, v) = <$typ as $crate::Unmarshal>::unmarshal(ctx)?;
                     return Ok((sig_bytes + vbytes, Self::$name(v)));


### PR DESCRIPTION
I've been working on an async version of this crate, and have been working on performances optimizations for it. One of the slowest types to marshal/unmarshal was variants. This is unfortunate because variants are used a lot in DBus.
The expense is largely because getting the signature string is very expensive. It involves creating `signature::Type` which can be expensive if it is a container and it involves allocating a `String`. 

Often the signature string is static and could be gotten with a lot less effort sort of like how `Signature::alignment` can get the alignment faster that using `signature::Type::alignment`
This proposes a `Signature::sig_str` which takes a `Cow<str>` and stores/appends a signature into it.

By providing a default implementation it shouldn't interfere with existing traits implementations.

Finally, a `Marshal::marshal_as_variant` method is added to take advantage of this change and various different places were changed to use this instead.