### PR TITLE
Create a `Signature::valid_slice` for improved marshalling performance

### DIFF
--- a/rustbus/src/lib.rs
+++ b/rustbus/src/lib.rs
@@ -119,6 +119,13 @@ pub enum ByteOrder {
     BigEndian,
 }
 
+impl ByteOrder {
+    const NATIVE: Self = match cfg!(target_endian = "little") {
+        true => ByteOrder::LittleEndian,
+        false => ByteOrder::BigEndian,
+    };
+}
+
 /// The different errors that can occur when dealing with messages
 #[derive(Debug, Eq, PartialEq)]
 pub enum Error {

--- a/rustbus/src/wire/marshal/traits.rs
+++ b/rustbus/src/wire/marshal/traits.rs
@@ -178,16 +178,18 @@ pub trait Signature {
     /// 1. The type `T` implementing `Signature` must be `Copy`.
     /// 2. The size of `T` must be **equivalent** to it's DBus alignment (see [here]).
     /// 3. Every possible bit-pattern must represent a valid instance of `T`.
+    ///    For example `std::num::NonZeroU32` does not meet this requirement `0` is invalid.
     /// 4. The type should not contain an Fd receieved from the message.
     ///    When implementing `Unmarshal` the type should only dependent the `'buf` lifetime.
     ///    It should never require the use of `'fds`.
-    /// For example `std::num::NonZeroU32` does not meet this requirement `0` is invalid.
     ///
     /// # Notes
     /// * This method exists because of limitiation with Rust type system.
     ///   Should `#[feature(specialization)]` ever become stablized this will hopefully be unnecessary.
     /// * This method should use the `ByteOrder` to check if it matches native order before returning `true`.
     ///   `ByteOrder::NATIVE` can be used to detect the native order.
+    ///
+    /// [here]: https://dbus.freedesktop.org/doc/dbus-specification.html#idm702
     #[inline]
     unsafe fn valid_slice(_bo: crate::ByteOrder) -> bool {
         false

--- a/rustbus/src/wire/marshal/traits.rs
+++ b/rustbus/src/wire/marshal/traits.rs
@@ -178,6 +178,9 @@ pub trait Signature {
     /// 1. The type `T` implementing `Signature` must be `Copy`.
     /// 2. The size of `T` must be **equivalent** to it's DBus alignment (see [here]).
     /// 3. Every possible bit-pattern must represent a valid instance of `T`.
+    /// 4. The type should not contain an Fd receieved from the message.
+    ///    When implementing `Unmarshal` the type should only dependent the `'buf` lifetime.
+    ///    It should never require the use of `'fds`.
     /// For example `std::num::NonZeroU32` does not meet this requirement `0` is invalid.
     ///
     /// # Notes

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -342,21 +342,6 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for String {
         Ok((bytes + padding, val))
     }
 }
-/*
-/// for byte arrays we can give an efficient method of decoding. This will bind the returned slice to the lifetime of the buffer.
-impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf [u8] {
-    fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (_, bytes_in_array) = u32::unmarshal(ctx)?;
-
-        let elements = &ctx.buf[ctx.offset..ctx.offset + bytes_in_array as usize];
-        ctx.offset += bytes_in_array as usize;
-
-        let total_bytes_used = padding + 4 + bytes_in_array as usize;
-
-        Ok((total_bytes_used, elements))
-    }
-}*/
 
 #[test]
 fn test_unmarshal_byte_array() {

--- a/rustbus/src/wire/util.rs
+++ b/rustbus/src/wire/util.rs
@@ -18,6 +18,7 @@ pub fn write_u16(val: u16, byteorder: ByteOrder, buf: &mut Vec<u8>) {
         ByteOrder::BigEndian => buf.extend(&val.to_be_bytes()[..]),
     }
 }
+#[inline]
 pub fn write_u32(val: u32, byteorder: ByteOrder, buf: &mut Vec<u8>) {
     match byteorder {
         ByteOrder::LittleEndian => buf.extend(&val.to_le_bytes()[..]),


### PR DESCRIPTION
Similar to a validation change I made earlier, this change can make unmarshalling and marshalling certain integer types a lot faster by skipping the looping unmarshal/marshal and just memcopying or creating direct references. 

I don't like this method of introducing this optimization, but Rust hasn't added specialization yet which would enable this with more traditional traits by allowing for overlapping trait implementations. I feel this PR's way is worth it until Rust's type system improves enough that it can be done more cleanly. 

It also introduces a `Cow` unmarshal that can take advantage of this if unmarshaling a native-endian message or automatically switch to a `Vec` if it is non-native.
