### PR TITLE
Fix error handling in keywallet example client

### DIFF
--- a/example_keywallet/src/bin/client/main.rs
+++ b/example_keywallet/src/bin/client/main.rs
@@ -37,7 +37,7 @@ fn main() {
         .wait_response(serial, rustbus::connection::Timeout::Infinite)
         .unwrap();
     println!("Header: {:?}", resp.dynheader);
-    match msg.typ {
+    match resp.typ {
         rustbus::message_builder::MessageType::Error => {
             println!(
                 "Error name: {}",

--- a/example_keywallet/src/bin/service/main.rs
+++ b/example_keywallet/src/bin/service/main.rs
@@ -82,7 +82,7 @@ fn service_handler(
             service_interface::handle_service_interface(ctx, matches, msg, env)
         }
         other => {
-            println!("Unkown interface called: {}", other);
+            println!("Unknown interface called: {}", other);
             Ok(Some(rustbus::standard_messages::unknown_method(
                 &msg.dynheader,
             )))
@@ -111,7 +111,7 @@ fn collection_handler(
             collection_interface::handle_collection_interface(ctx, matches, msg, env)
         }
         other => {
-            println!("Unkown interface called: {}", other);
+            println!("Unknown interface called: {}", other);
             Ok(Some(rustbus::standard_messages::unknown_method(
                 &msg.dynheader,
             )))
@@ -140,7 +140,7 @@ fn item_handler(
             item_interface::handle_item_interface(ctx, matches, msg, env)
         }
         other => {
-            println!("Unkown interface called: {}", other);
+            println!("Unknown interface called: {}", other);
             Ok(Some(rustbus::standard_messages::unknown_method(
                 &msg.dynheader,
             )))
@@ -183,7 +183,7 @@ fn session_handler(
                     Ok(None)
                 }
                 other => {
-                    println!("Unkown method called: {}", other);
+                    println!("Unknown method called: {}", other);
                     Ok(Some(rustbus::standard_messages::unknown_method(
                         &msg.dynheader,
                     )))
@@ -191,7 +191,7 @@ fn session_handler(
             }
         }
         other => {
-            println!("Unkown interface called: {}", other);
+            println!("Unknown interface called: {}", other);
             Ok(Some(rustbus::standard_messages::unknown_method(
                 &msg.dynheader,
             )))
@@ -217,7 +217,7 @@ fn main() {
         .write_all()
         .unwrap();
 
-    // The responses content should be looked at. ATM we just assume the name aquistion worked...
+    // The response content should be looked at. ATM we just assume the name acquisition worked...
     let _resp = con
         .recv
         .get_next_message(rustbus::connection::Timeout::Infinite)


### PR DESCRIPTION
The keywallet example client was accidentally matching on the request type instead of the response type, causing errors to be handled incorrectly.

Also, fix some typos in the keywallet example service.