### PR TITLE
Fix session bus path detection for dbus 1.14.4+

### DIFF
--- a/rustbus/src/connection.rs
+++ b/rustbus/src/connection.rs
@@ -81,20 +81,13 @@ type Result<T> = std::result::Result<T, Error>;
 
 fn parse_dbus_addr_str(addr: &str) -> Result<UnixAddr> {
     // split the address string into <system>:rest
-    let addr_parts: Vec<&str> = addr.split(':').collect();
-    let addr_system = addr_parts.get(0).unwrap_or(&addr);
-    if *addr_system != "unix" {
+    let (addr_system, addr_pairs) = addr.split_once(':').ok_or(Error::NoAddressFound)?;
+    if addr_system != "unix" {
         return Err(Error::AddressTypeNotSupported(addr.to_owned()));
     }
 
     // split the rest of the address string into each <key>=<value> pair
-    let addr_keys: Vec<&str> = addr_parts
-        .get(1)
-        .ok_or(Error::NoAddressFound)?
-        .split(',')
-        .collect();
-
-    for pair in addr_keys {
+    for pair in addr_pairs.split(',') {
         let (key, value) = pair
             .split_once('=')
             .ok_or_else(|| Error::AddressTypeNotSupported(addr.to_owned()))?;


### PR DESCRIPTION
DBus 1.14.4 makes a behavior change (
https://raw.githubusercontent.com/freedesktop/dbus/dbus-1.14/NEWS ) to some users' session bus paths, which can result in a DBUS_SESSION_BUS_ADDRESS of the format:

    unix:path=/tmp/dbus-28xxxxxxxx,guid=xxxxxxxxx8198ffd295e9c5a5637c20bf

Particularly, the DBus session keys are appended to the end of the filesystem path. This commit fixes rustbus' session bus path detection algorithm for systems impacted.

(I found this [after a dbus update broke mpris-notifier](https://github.com/l1na-forever/mpris-notifier/issues/2) :crying_cat_face: )