### PR TITLE
implement (Un)marshall and Signature for f64

### DIFF
--- a/rustbus/src/params/conversion.rs
+++ b/rustbus/src/params/conversion.rs
@@ -201,6 +201,12 @@ impl<'a, 'e> Param<'a, 'e> {
             _ => Err(self),
         }
     }
+    pub fn into_f64(self) -> Result<f64, Param<'a, 'e>> {
+        match self {
+            Param::Base(Base::Double(s)) => Ok(f64::from_bits(s)),
+            _ => Err(self),
+        }
+    }
 }
 
 //
@@ -355,6 +361,12 @@ impl<'a> Base<'a> {
             _ => Err(self),
         }
     }
+    pub fn into_f64(self) -> Result<f64, Self> {
+        match self {
+            Base::Double(s) => Ok(f64::from_bits(s)),
+            _ => Err(self),
+        }
+    }
 }
 
 impl<'a> std::convert::From<&Base<'a>> for signature::Base {
@@ -493,6 +505,17 @@ impl<'a> std::convert::TryFrom<&Base<'a>> for i64 {
     fn try_from(b: &Base) -> std::result::Result<i64, ConversionError> {
         if let Base::Int64(value) = b {
             Ok(*value)
+        } else {
+            Err(ConversionError::InvalidType)
+        }
+    }
+}
+
+impl<'a> std::convert::TryFrom<&Base<'a>> for f64 {
+    type Error = ConversionError;
+    fn try_from(b: &Base) -> std::result::Result<f64, ConversionError> {
+        if let Base::Double(value) = b {
+            Ok(f64::from_bits(*value))
         } else {
             Err(ConversionError::InvalidType)
         }
@@ -652,6 +675,11 @@ impl<'a> std::convert::From<i64> for Base<'a> {
         Base::Int64(s)
     }
 }
+impl<'a> std::convert::From<f64> for Base<'a> {
+    fn from(s: f64) -> Self {
+        Base::Double(s.to_bits())
+    }
+}
 impl<'a> std::convert::From<&'a bool> for Base<'a> {
     fn from(s: &'a bool) -> Self {
         Base::BooleanRef(s)
@@ -675,6 +703,11 @@ impl<'a> std::convert::From<&'a u32> for Base<'a> {
 impl<'a> std::convert::From<&'a u64> for Base<'a> {
     fn from(s: &'a u64) -> Self {
         Base::Uint64Ref(s)
+    }
+}
+impl<'a> std::convert::From<&'a f64> for Base<'a> {
+    fn from(s: &'a f64) -> Self {
+        Base::Double(s.to_bits())
     }
 }
 impl<'a> std::convert::From<&'a i16> for Base<'a> {

--- a/rustbus/src/wire/marshal/traits/base.rs
+++ b/rustbus/src/wire/marshal/traits/base.rs
@@ -230,6 +230,34 @@ impl Marshal for bool {
     }
 }
 
+impl Signature for f64 {
+    #[inline]
+    fn signature() -> crate::signature::Type {
+        crate::signature::Type::Base(crate::signature::Base::Double)
+    }
+    #[inline]
+    fn alignment() -> usize {
+        8
+    }
+    #[inline]
+    unsafe fn valid_slice(bo: crate::ByteOrder) -> bool {
+        bo == crate::ByteOrder::NATIVE
+    }
+    fn sig_str(sig: &mut SignatureBuffer) {
+        sig.push_static("d");
+    }
+    fn has_sig(sig: &str) -> bool {
+        sig.starts_with('d')
+    }
+}
+impl Marshal for f64 {
+    fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), MarshalError> {
+        ctx.align_to(Self::alignment());
+        util::write_u64(self.to_bits(), ctx.byteorder, ctx.buf);
+        Ok(())
+    }
+}
+
 impl Signature for String {
     #[inline]
     fn signature() -> crate::signature::Type {

--- a/rustbus/src/wire/unmarshal/traits/base.rs
+++ b/rustbus/src/wire/unmarshal/traits/base.rs
@@ -85,6 +85,15 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for bool {
     }
 }
 
+impl<'buf, 'fds> Unmarshal<'buf, 'fds> for f64 {
+    fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
+        let padding = ctx.align_to(Self::alignment())?;
+        let (bytes, val) = util::parse_u64(&ctx.buf[ctx.offset..], ctx.byteorder)?;
+        ctx.offset += bytes;
+        Ok((bytes + padding, f64::from_bits(val)))
+    }
+}
+
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf str {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;


### PR DESCRIPTION
I did not touch `Base::Double` and left it holding `u64` to avoid breaking changes.

I did not implement `From<&'a f64> for Base<'a>` because it would require a transmute from `&'a f64` to `&'a u64`, which may be safe, but...

1. Is there any value in having the `...Ref` variants for scalar variants? Obviously it is needed for strings, but what is the point of holding a shared reference to a number? Please correct me if there are usecases.
2. If `...Ref`s are useful, then changing `Double` and `DoubleRef` to hold `f64` is a better solution. That's a breaking change, but the README says it's fine :)

Closes #86