### PR TITLE
make Variant<T>(T) useful by makeing the field public

### DIFF
--- a/rustbus/src/wire/marshal/traits/container.rs
+++ b/rustbus/src/wire/marshal/traits/container.rs
@@ -313,7 +313,7 @@ impl<E: Marshal> Marshal for &[E] {
     }
 }
 
-pub struct Variant<T: Marshal + Signature>(T);
+pub struct Variant<T: Marshal + Signature>(pub T);
 
 impl<T: Marshal + Signature> Signature for Variant<T> {
     #[inline]


### PR DESCRIPTION
Currently `Variant` is useless because it cannot be created.