### PR TITLE
implement Signature and Marshal for params::Variant

### DIFF
--- a/rustbus/src/tests/verify_marshalling.rs
+++ b/rustbus/src/tests/verify_marshalling.rs
@@ -296,4 +296,16 @@ fn verify_variant_marshalling() {
     // signature ++ padding ++ 32u8
     assert_eq!(ctx.buf, &[1, b'y', 0, 32]);
     ctx.buf.clear();
+
+    let param = crate::params::Param::Base(crate::params::Base::Byte(16));
+    let v = crate::params::Variant {
+        sig: crate::signature::Type::Base(crate::signature::Base::Byte),
+        value: param,
+    };
+
+    v.marshal(ctx).unwrap();
+
+    // signature ++ padding ++ 16u8
+    assert_eq!(ctx.buf, &[1, b'y', 0, 16]);
+    ctx.buf.clear();
 }


### PR DESCRIPTION
My usecase: I was implementing `org.freedesktop.DBus.Properties.GetAll` which returns `a{sv}`. In Rust's types that would be `HashMap<&str, Variant>`, but I couldn't use it because of the missing impls. `Container::make_dict_ref("s", "v", ...)` works, but not nearly as ergonomic and forces to go through `push_old_param` instead of the new `push_param`.

I did not implement `Unmarshal`, because I didn't need it yet. Let me know it I should add it too for completeness.