### PR TITLE
avoid raw pointre casts using "as"; perfer extend_from_slice

### DIFF
--- a/rustbus/src/auth.rs
+++ b/rustbus/src/auth.rs
@@ -35,7 +35,7 @@ fn read_message(stream: &mut UnixStream, buf: &mut Vec<u8>) -> std::io::Result<S
     let mut tmpbuf = [0u8; 512];
     while !has_line_ending(buf) {
         let bytes = stream.read(&mut tmpbuf[..])?;
-        buf.extend(&tmpbuf[..bytes])
+        buf.extend_from_slice(&tmpbuf[..bytes])
     }
     let idx = find_line_ending(buf).unwrap();
     let line = buf.drain(0..idx).collect::<Vec<_>>();

--- a/rustbus/src/connection/ll_conn.rs
+++ b/rustbus/src/connection/ll_conn.rs
@@ -101,7 +101,7 @@ impl RecvConn {
 
         self.cmsgs_in.extend(msg.cmsgs());
         let bytes = msg.bytes;
-        self.msg_buf_in.extend(&mut tmpbuf[..bytes].iter().copied());
+        self.msg_buf_in.extend_from_slice(&tmpbuf[..bytes]);
         Ok(())
     }
 

--- a/rustbus/src/wire/marshal/traits/container.rs
+++ b/rustbus/src/wire/marshal/traits/container.rs
@@ -304,7 +304,7 @@ impl<E: Marshal> Marshal for &[E] {
                 assert!(len <= u32::MAX as usize);
                 write_u32(len as u32, ctx.byteorder, ctx.buf);
                 ctx.align_to(alignment);
-                let ptr = *self as *const [E] as *const u8;
+                let ptr = self.as_ptr().cast::<u8>();
                 let slice = std::slice::from_raw_parts(ptr, len);
                 ctx.buf.extend_from_slice(slice);
                 return Ok(());

--- a/rustbus/src/wire/unmarshal/traits/container.rs
+++ b/rustbus/src/wire/unmarshal/traits/container.rs
@@ -169,7 +169,7 @@ where
 
     // cast the slice from u8 to the target type
     let elem_cnt = bytes_in_array / alignment;
-    let ptr = content_slice as *const [u8] as *const E;
+    let ptr = content_slice.as_ptr().cast::<E>();
     let slice = std::slice::from_raw_parts(ptr, elem_cnt);
 
     ctx.offset += bytes_in_array;

--- a/rustbus/src/wire/util.rs
+++ b/rustbus/src/wire/util.rs
@@ -18,21 +18,21 @@ pub fn pad_to_align(align_to: usize, buf: &mut Vec<u8>) {
 
 pub fn write_u16(val: u16, byteorder: ByteOrder, buf: &mut Vec<u8>) {
     match byteorder {
-        ByteOrder::LittleEndian => buf.extend(&val.to_le_bytes()[..]),
-        ByteOrder::BigEndian => buf.extend(&val.to_be_bytes()[..]),
+        ByteOrder::LittleEndian => buf.extend_from_slice(&val.to_le_bytes()),
+        ByteOrder::BigEndian => buf.extend_from_slice(&val.to_be_bytes()),
     }
 }
 #[inline]
 pub fn write_u32(val: u32, byteorder: ByteOrder, buf: &mut Vec<u8>) {
     match byteorder {
-        ByteOrder::LittleEndian => buf.extend(&val.to_le_bytes()[..]),
-        ByteOrder::BigEndian => buf.extend(&val.to_be_bytes()[..]),
+        ByteOrder::LittleEndian => buf.extend_from_slice(&val.to_le_bytes()),
+        ByteOrder::BigEndian => buf.extend_from_slice(&val.to_be_bytes()),
     }
 }
 pub fn write_u64(val: u64, byteorder: ByteOrder, buf: &mut Vec<u8>) {
     match byteorder {
-        ByteOrder::LittleEndian => buf.extend(&val.to_le_bytes()[..]),
-        ByteOrder::BigEndian => buf.extend(&val.to_be_bytes()[..]),
+        ByteOrder::LittleEndian => buf.extend_from_slice(&val.to_le_bytes()),
+        ByteOrder::BigEndian => buf.extend_from_slice(&val.to_be_bytes()),
     }
 }
 


### PR DESCRIPTION
`ptr::cast<T>` is supposed to be a more "safe" way to cast pointers. `extend_from_slice` may be more performant than `extend`.