### PR TITLE
update nix to 0.28

### DIFF
--- a/rustbus/Cargo.toml
+++ b/rustbus/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/KillingSpark/rustbus"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nix = { version = "0.27", features = ["fs", "poll", "socket", "uio", "user"] }
+nix = { version = "0.28", features = ["fs", "poll", "socket", "uio", "user"] }
 rustbus_derive = {version = "0.5.0", path = "../rustbus_derive"}
 thiserror = "1.0"
 

--- a/rustbus/src/connection/ll_conn.rs
+++ b/rustbus/src/connection/ll_conn.rs
@@ -43,6 +43,7 @@ pub struct DuplexConn {
 }
 
 impl RecvConn {
+    #[deprecated = "use poll() or select() on the file descriptor"]
     pub fn can_read_from_source(&self) -> io::Result<bool> {
         let mut fdset = nix::sys::select::FdSet::new();
         fdset.insert(self.stream.as_fd());

--- a/rustbus/src/tests/fdpassing.rs
+++ b/rustbus/src/tests/fdpassing.rs
@@ -2,6 +2,7 @@ use crate::connection;
 use crate::message_builder::MessageBuilder;
 use std::io::Read;
 use std::io::Write;
+use std::os::fd::IntoRawFd;
 use std::os::unix::io::FromRawFd;
 
 const TEST_STRING: &str = "This will be sent over the fd\n";
@@ -30,8 +31,8 @@ fn test_fd_passing() {
     std::thread::sleep(std::time::Duration::from_secs(1));
 
     let rw = nix::unistd::pipe().unwrap();
-    let mut readfile = unsafe { std::fs::File::from_raw_fd(rw.0) };
-    send_fd(&mut con1, crate::wire::UnixFd::new(rw.1)).unwrap();
+    let mut readfile = std::fs::File::from(rw.0);
+    send_fd(&mut con1, crate::wire::UnixFd::new(rw.1.into_raw_fd())).unwrap();
 
     let sig = loop {
         let signal = con2.wait_signal(connection::Timeout::Infinite).unwrap();


### PR DESCRIPTION
And deprecate `RecvConn::can_read_from_source` as discussed earlier.