### PR TITLE
Refactor parsing

### DIFF
--- a/rustbus/Cargo.toml
+++ b/rustbus/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/KillingSpark/rustbus"
 
 [dependencies]
 nix = { version = "0.28", features = ["fs", "poll", "socket", "uio", "user"] }
-rustbus_derive = {version = "0.5.0", path = "../rustbus_derive"}
+rustbus_derive = {version = "0.6.0", path = "../rustbus_derive"}
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rustbus/benches/marshal_benchmark.rs
+++ b/rustbus/benches/marshal_benchmark.rs
@@ -6,16 +6,18 @@ use rustbus::wire::marshal::marshal;
 use rustbus::wire::unmarshal::unmarshal_dynamic_header;
 use rustbus::wire::unmarshal::unmarshal_header;
 use rustbus::wire::unmarshal::unmarshal_next_message;
+use rustbus::wire::unmarshal_context::Cursor;
 
 fn marsh(msg: &rustbus::message_builder::MarshalledMessage, buf: &mut Vec<u8>) {
     marshal(msg, 0, buf).unwrap();
 }
 
 fn unmarshal(buf: &[u8]) {
-    let (hdrbytes, header) = unmarshal_header(buf, 0).unwrap();
-    let (dynhdrbytes, dynheader) = unmarshal_dynamic_header(&header, buf, hdrbytes).unwrap();
-    let (_, _unmarshed_msg) =
-        unmarshal_next_message(&header, dynheader, buf.to_vec(), hdrbytes + dynhdrbytes).unwrap();
+    let mut cursor = Cursor::new(buf);
+    let header = unmarshal_header(&mut cursor).unwrap();
+    let dynheader = unmarshal_dynamic_header(&header, &mut cursor).unwrap();
+    let _unmarshed_msg =
+        unmarshal_next_message(&header, dynheader, buf.to_vec(), cursor.consumed()).unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/rustbus/benches/marshal_benchmark.rs
+++ b/rustbus/benches/marshal_benchmark.rs
@@ -17,7 +17,8 @@ fn unmarshal(buf: &[u8]) {
     let header = unmarshal_header(&mut cursor).unwrap();
     let dynheader = unmarshal_dynamic_header(&header, &mut cursor).unwrap();
     let _unmarshed_msg =
-        unmarshal_next_message(&header, dynheader, buf.to_vec(), cursor.consumed()).unwrap();
+        unmarshal_next_message(&header, dynheader, buf.to_vec(), cursor.consumed(), vec![])
+            .unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/rustbus/fuzz/fuzz_targets/fuzz_unmarshal.rs
+++ b/rustbus/fuzz/fuzz_targets/fuzz_unmarshal.rs
@@ -5,23 +5,20 @@ extern crate rustbus;
 
 fuzz_target!(|data: &[u8]| {
     let mut cursor = rustbus::wire::unmarshal_context::Cursor::new(data);
-    let header = match rustbus::wire::unmarshal::unmarshal_header(&mut cursor) {
-        Ok(head) => head,
-        Err(_) => return,
+    let Ok(header) = rustbus::wire::unmarshal::unmarshal_header(&mut cursor) else {
+        return;
     };
-    let dynheader = match rustbus::wire::unmarshal::unmarshal_dynamic_header(&header, &mut cursor) {
-        Ok(head) => head,
-        Err(_) => return,
+    let Ok(dynheader) = rustbus::wire::unmarshal::unmarshal_dynamic_header(&header, &mut cursor) else {
+        return;
     };
 
-    let msg = match rustbus::wire::unmarshal::unmarshal_next_message(
+    let Ok(msg) = rustbus::wire::unmarshal::unmarshal_next_message(
         &header,
         dynheader,
         data.to_vec(),
         cursor.consumed(),
-    ) {
-        Ok(msg) => msg,
-        Err(_) => return,
+    ) else {
+        return;
     };
     try_unmarhal_traits(&msg);
     msg.unmarshall_all().ok();

--- a/rustbus/fuzz/fuzz_targets/fuzz_unmarshal.rs
+++ b/rustbus/fuzz/fuzz_targets/fuzz_unmarshal.rs
@@ -17,6 +17,7 @@ fuzz_target!(|data: &[u8]| {
         dynheader,
         data.to_vec(),
         cursor.consumed(),
+        vec![],
     ) else {
         return;
     };

--- a/rustbus/src/bin/fuzz_artifact.rs
+++ b/rustbus/src/bin/fuzz_artifact.rs
@@ -19,28 +19,26 @@ fn run_artifact(path: &str) {
     let data = &data;
 
     let mut cursor = Cursor::new(data);
-    let header = match rustbus::wire::unmarshal::unmarshal_header(&mut cursor) {
-        Ok(head) => head,
-        Err(_) => return,
+    let Ok(header) = rustbus::wire::unmarshal::unmarshal_header(&mut cursor) else {
+        return;
     };
 
     println!("Header: {:?}", header);
 
-    let dynheader = match rustbus::wire::unmarshal::unmarshal_dynamic_header(&header, &mut cursor) {
-        Ok(head) => head,
-        Err(_) => return,
+    let Ok(dynheader) = rustbus::wire::unmarshal::unmarshal_dynamic_header(&header, &mut cursor)
+    else {
+        return;
     };
 
     println!("Dynheader: {:?}", dynheader);
 
-    let msg = match rustbus::wire::unmarshal::unmarshal_next_message(
+    let Ok(msg) = rustbus::wire::unmarshal::unmarshal_next_message(
         &header,
         dynheader,
         data.clone(),
         cursor.consumed(),
-    ) {
-        Ok(msg) => msg,
-        Err(_) => return,
+    ) else {
+        return;
     };
 
     println!("Message: {:?}", msg);

--- a/rustbus/src/bin/fuzz_artifact.rs
+++ b/rustbus/src/bin/fuzz_artifact.rs
@@ -37,6 +37,7 @@ fn run_artifact(path: &str) {
         dynheader,
         data.clone(),
         cursor.consumed(),
+        vec![],
     ) else {
         return;
     };

--- a/rustbus/src/connection/ll_conn.rs
+++ b/rustbus/src/connection/ll_conn.rs
@@ -238,7 +238,7 @@ impl RecvConn {
                 }
                 _ => {
                     // TODO what to do?
-                    eprintln!("Cmsg other than ScmRights: {:?}", cmsg);
+                    // eprintln!("Cmsg other than ScmRights: {:?}", cmsg);
                 }
             }
         }

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -269,14 +269,13 @@ impl MarshalledMessage {
         } else {
             let sigs: Vec<_> = crate::signature::Type::parse_description(&self.body.sig)?;
 
-            let (_, params) = crate::wire::unmarshal::unmarshal_body(
+            crate::wire::unmarshal::unmarshal_body(
                 self.body.byteorder,
                 &sigs,
                 self.body.get_buf(),
                 &self.body.raw_fds,
                 0,
-            )?;
-            params
+            )?
         };
         Ok(message::Message {
             dynheader: self.dynheader,
@@ -797,8 +796,8 @@ impl<'fds, 'body: 'fds> MessageBodyParser<'body> {
                 self.buf_idx,
             );
             match T::unmarshal(&mut ctx) {
-                Ok((bytes, res)) => {
-                    self.buf_idx += bytes;
+                Ok(res) => {
+                    self.buf_idx = self.body.get_buf().len() - ctx.remainder().len();
                     self.sig_idx += expected_sig.len();
                     Ok(res)
                 }
@@ -914,8 +913,8 @@ impl<'fds, 'body: 'fds> MessageBodyParser<'body> {
             let sig = &crate::signature::Type::parse_description(sig_str).unwrap()[0];
 
             match crate::wire::unmarshal::container::unmarshal_with_sig(sig, &mut ctx) {
-                Ok((bytes, res)) => {
-                    self.buf_idx += bytes;
+                Ok(res) => {
+                    self.buf_idx = self.body.get_buf().len() - ctx.remainder().len();
                     self.sig_idx += sig_str.len();
                     Ok(res)
                 }

--- a/rustbus/src/params/types.rs
+++ b/rustbus/src/params/types.rs
@@ -227,7 +227,7 @@ impl Marshal for Variant<'_, '_> {
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for Variant<'buf, 'fds> {
     fn unmarshal(
-        ctx: &mut crate::wire::unmarshal::UnmarshalContext<'fds, 'buf>,
+        ctx: &mut crate::wire::unmarshal_context::UnmarshalContext<'fds, 'buf>,
     ) -> crate::wire::unmarshal::UnmarshalResult<Self> {
         crate::wire::unmarshal::container::unmarshal_variant(ctx)
     }

--- a/rustbus/src/tests.rs
+++ b/rustbus/src/tests.rs
@@ -52,7 +52,7 @@ fn test_marshal_unmarshal() {
     assert_eq!(headers_plus_padding, buf.len());
 
     let unmarshed_msg =
-        unmarshal_next_message(&header, dynheader, msg.get_buf().to_vec(), 0).unwrap();
+        unmarshal_next_message(&header, dynheader, msg.get_buf().to_vec(), 0, vec![]).unwrap();
 
     let msg = unmarshed_msg.unmarshall_all().unwrap();
 

--- a/rustbus/src/tests/fdpassing.rs
+++ b/rustbus/src/tests/fdpassing.rs
@@ -110,9 +110,9 @@ fn test_fd_marshalling() {
 
     // assert the correct representation, where fds have been put into the fd array and the index is marshalled in the message
     assert_eq!(sig.body.get_buf(), &[0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0]);
-    assert_ne!(&sig.body.raw_fds[0], &test_fd1);
-    assert_ne!(&sig.body.raw_fds[1], &test_fd2);
-    assert_ne!(&sig.body.raw_fds[2], &test_fd3);
+    assert_ne!(&sig.body.get_fds()[0], &test_fd1);
+    assert_ne!(&sig.body.get_fds()[1], &test_fd2);
+    assert_ne!(&sig.body.get_fds()[2], &test_fd3);
 
     // assert that unmarshalling yields the correct fds
     let mut parser = sig.body.parser();

--- a/rustbus/src/tests/fdpassing.rs
+++ b/rustbus/src/tests/fdpassing.rs
@@ -9,8 +9,10 @@ const TEST_STRING: &str = "This will be sent over the fd\n";
 
 #[test]
 fn test_fd_passing() {
-    let mut con1 =
-        connection::rpc_conn::RpcConn::system_conn(connection::Timeout::Infinite).unwrap();
+    let Ok(mut con1) = connection::rpc_conn::RpcConn::system_conn(connection::Timeout::Infinite)
+    else {
+        return;
+    };
     let mut con2 =
         connection::rpc_conn::RpcConn::system_conn(connection::Timeout::Infinite).unwrap();
     con1.send_message(&mut crate::standard_messages::hello())

--- a/rustbus/src/wire.rs
+++ b/rustbus/src/wire.rs
@@ -6,6 +6,7 @@ pub mod unmarshal;
 pub mod util;
 pub mod validate_raw;
 pub mod variant_macros;
+pub mod unmarshal_context;
 
 mod wrapper_types;
 pub use wrapper_types::unixfd::UnixFd;

--- a/rustbus/src/wire.rs
+++ b/rustbus/src/wire.rs
@@ -3,10 +3,10 @@
 pub mod errors;
 pub mod marshal;
 pub mod unmarshal;
+pub mod unmarshal_context;
 pub mod util;
 pub mod validate_raw;
 pub mod variant_macros;
-pub mod unmarshal_context;
 
 mod wrapper_types;
 pub use wrapper_types::unixfd::UnixFd;

--- a/rustbus/src/wire/marshal.rs
+++ b/rustbus/src/wire/marshal.rs
@@ -42,7 +42,7 @@ pub fn marshal(
 
     // set the correct message length
     insert_u32(
-        msg.body.byteorder,
+        msg.body.byteorder(),
         msg.get_buf().len() as u32,
         &mut buf[4..8],
     );
@@ -54,7 +54,7 @@ fn marshal_header(
     chosen_serial: u32,
     buf: &mut Vec<u8>,
 ) -> MarshalResult<()> {
-    let byteorder = msg.body.byteorder;
+    let byteorder = msg.body.byteorder();
 
     match byteorder {
         ByteOrder::BigEndian => {
@@ -105,10 +105,10 @@ fn marshal_header(
     if let Some(obj) = &msg.dynheader.object {
         marshal_header_field(byteorder, &HeaderField::Path(obj.clone()), buf)?;
     }
-    if !msg.body.raw_fds.is_empty() {
+    if !msg.body.get_fds().is_empty() {
         marshal_header_field(
             byteorder,
-            &HeaderField::UnixFds(msg.body.raw_fds.len() as u32),
+            &HeaderField::UnixFds(msg.body.get_fds().len() as u32),
             buf,
         )?;
     }

--- a/rustbus/src/wire/marshal/traits/container.rs
+++ b/rustbus/src/wire/marshal/traits/container.rs
@@ -241,7 +241,7 @@ impl<E1: Marshal, E2: Marshal, E3: Marshal, E4: Marshal, E5: Marshal> Marshal
 
 impl<E: Marshal> Marshal for Vec<E> {
     fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), MarshalError> {
-        self.as_slice().marshal(ctx)
+        <&[E] as Marshal>::marshal(&self.as_slice(), ctx)
     }
 }
 
@@ -270,7 +270,30 @@ impl<E: Signature> Signature for [E] {
 }
 impl<E: Marshal> Marshal for [E] {
     fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), MarshalError> {
-        (&self).marshal(ctx)
+        <&[E] as Marshal>::marshal(&self, ctx)
+    }
+}
+
+impl<E: Signature, const N: usize> Signature for [E; N] {
+    #[inline]
+    fn signature() -> crate::signature::Type {
+        <[E]>::signature()
+    }
+    #[inline]
+    fn alignment() -> usize {
+        <[E]>::alignment()
+    }
+    #[inline]
+    fn sig_str(s_buf: &mut SignatureBuffer) {
+        <[E]>::sig_str(s_buf)
+    }
+    fn has_sig(sig: &str) -> bool {
+        <[E]>::has_sig(sig)
+    }
+}
+impl<E: Marshal, const N: usize> Marshal for [E; N] {
+    fn marshal(&self, ctx: &mut MarshalContext) -> Result<(), MarshalError> {
+        <&[E] as Marshal>::marshal(&self.as_slice(), ctx)
     }
 }
 

--- a/rustbus/src/wire/unmarshal.rs
+++ b/rustbus/src/wire/unmarshal.rs
@@ -104,7 +104,7 @@ pub fn unmarshal_dynamic_header(
     Ok((fields_bytes_used, hdr))
 }
 
-pub fn unmarshal_body<'a, 'e>(
+pub fn unmarshal_body(
     byteorder: ByteOrder,
     sigs: &[crate::signature::Type],
     buf: &[u8],

--- a/rustbus/src/wire/unmarshal.rs
+++ b/rustbus/src/wire/unmarshal.rs
@@ -24,6 +24,7 @@ pub mod traits;
 use container::*;
 
 use super::unmarshal_context::{Cursor, UnmarshalContext};
+use super::UnixFd;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Header {
@@ -120,6 +121,7 @@ pub fn unmarshal_next_message(
     dynheader: DynamicHeader,
     buf: Vec<u8>,
     offset: usize,
+    raw_fds: Vec<UnixFd>,
 ) -> UnmarshalResult<MarshalledMessage> {
     let sig = dynheader.signature.clone().unwrap_or_else(|| "".to_owned());
     let padding = align_offset(8, &buf, offset)?;
@@ -127,7 +129,7 @@ pub fn unmarshal_next_message(
     if header.body_len == 0 {
         let msg = MarshalledMessage {
             dynheader,
-            body: MarshalledMessageBody::from_parts(vec![], 0, vec![], sig, header.byteorder),
+            body: MarshalledMessageBody::from_parts(vec![], 0, raw_fds, sig, header.byteorder),
             typ: header.typ,
             flags: header.flags,
         };
@@ -144,7 +146,7 @@ pub fn unmarshal_next_message(
 
         let msg = MarshalledMessage {
             dynheader,
-            body: MarshalledMessageBody::from_parts(buf, offset, vec![], sig, header.byteorder),
+            body: MarshalledMessageBody::from_parts(buf, offset, raw_fds, sig, header.byteorder),
             typ: header.typ,
             flags: header.flags,
         };

--- a/rustbus/src/wire/unmarshal/iter.rs
+++ b/rustbus/src/wire/unmarshal/iter.rs
@@ -143,12 +143,8 @@ impl<'a, 'parent> DictEntryIter<'a> {
         let iter = if self.counter == 0 {
             // read the key value
 
-            let mut ctx = UnmarshalContext::new(
-                &[],
-                self.byteorder,
-                self.source,
-                *self.current_offset,
-            );
+            let mut ctx =
+                UnmarshalContext::new(&[], self.byteorder, self.source, *self.current_offset);
 
             match unmarshal_base(self.key_sig, &mut ctx) {
                 Ok((bytes, param)) => {
@@ -241,12 +237,7 @@ impl<'a, 'parent> ParamIter<'a> {
 
         match new_sig {
             signature::Type::Base(b) => {
-                let mut ctx = UnmarshalContext::new(
-                    &[],
-                    byteorder,
-                    source,
-                    *offset,
-                );
+                let mut ctx = UnmarshalContext::new(&[], byteorder, source, *offset);
                 match unmarshal_base(*b, &mut ctx) {
                     Ok((bytes, param)) => {
                         *offset += bytes;

--- a/rustbus/src/wire/unmarshal/param/base.rs
+++ b/rustbus/src/wire/unmarshal/param/base.rs
@@ -28,13 +28,8 @@ pub fn unmarshal_base(
             Ok(params::Base::Uint32(val))
         }
         signature::Base::UnixFd => {
-            let idx = ctx.read_u32()?;
-            if ctx.fds.len() <= idx as usize {
-                Err(UnmarshalError::BadFdIndex(idx as usize))
-            } else {
-                let val = &ctx.fds[idx as usize];
-                Ok(params::Base::UnixFd(val.clone()))
-            }
+            let val = ctx.read_unixfd()?;
+            Ok(params::Base::UnixFd(val))
         }
         signature::Base::Int32 => {
             let val = ctx.read_i32()?;

--- a/rustbus/src/wire/unmarshal/param/base.rs
+++ b/rustbus/src/wire/unmarshal/param/base.rs
@@ -12,67 +12,67 @@ pub fn unmarshal_base(
 ) -> UnmarshalResult<params::Base<'static>> {
     match typ {
         signature::Base::Byte => {
-            let (bytes, val) = ctx.read_u8()?;
-            Ok((bytes, params::Base::Byte(val)))
+            let val = ctx.read_u8()?;
+            Ok(params::Base::Byte(val))
         }
         signature::Base::Uint16 => {
-            let (bytes, val) = ctx.read_u16()?;
-            Ok((bytes, params::Base::Uint16(val)))
+            let val = ctx.read_u16()?;
+            Ok(params::Base::Uint16(val))
         }
         signature::Base::Int16 => {
-            let (bytes, val) = ctx.read_i16()?;
-            Ok((bytes, params::Base::Int16(val)))
+            let val = ctx.read_i16()?;
+            Ok(params::Base::Int16(val))
         }
         signature::Base::Uint32 => {
-            let (bytes, val) = ctx.read_u32()?;
-            Ok((bytes, params::Base::Uint32(val)))
+            let val = ctx.read_u32()?;
+            Ok(params::Base::Uint32(val))
         }
         signature::Base::UnixFd => {
-            let (bytes, idx) = ctx.read_u32()?;
+            let idx = ctx.read_u32()?;
             if ctx.fds.len() <= idx as usize {
                 Err(UnmarshalError::BadFdIndex(idx as usize))
             } else {
                 let val = &ctx.fds[idx as usize];
-                Ok((bytes, params::Base::UnixFd(val.clone())))
+                Ok(params::Base::UnixFd(val.clone()))
             }
         }
         signature::Base::Int32 => {
-            let (bytes, val) = ctx.read_i32()?;
-            Ok((bytes, params::Base::Int32(val)))
+            let val = ctx.read_i32()?;
+            Ok(params::Base::Int32(val))
         }
         signature::Base::Uint64 => {
-            let (bytes, val) = ctx.read_u64()?;
-            Ok((bytes, params::Base::Uint64(val)))
+            let val = ctx.read_u64()?;
+            Ok(params::Base::Uint64(val))
         }
         signature::Base::Int64 => {
-            let (bytes, val) = ctx.read_i64()?;
-            Ok((bytes, params::Base::Int64(val)))
+            let val = ctx.read_i64()?;
+            Ok(params::Base::Int64(val))
         }
         signature::Base::Double => {
-            let (bytes, val) = ctx.read_u64()?;
-            Ok((bytes, params::Base::Double(val)))
+            let val = ctx.read_u64()?;
+            Ok(params::Base::Double(val))
         }
         signature::Base::Boolean => {
-            let (bytes, val) = ctx.read_u32()?;
+            let val = ctx.read_u32()?;
             match val {
-                0 => Ok((bytes, params::Base::Boolean(false))),
-                1 => Ok((bytes, params::Base::Boolean(true))),
+                0 => Ok(params::Base::Boolean(false)),
+                1 => Ok(params::Base::Boolean(true)),
                 _ => Err(UnmarshalError::InvalidBoolean),
             }
         }
         signature::Base::String => {
-            let (bytes, string) = ctx.read_str()?;
-            Ok((bytes, params::Base::String(string.into())))
+            let string = ctx.read_str()?;
+            Ok(params::Base::String(string.into()))
         }
         signature::Base::ObjectPath => {
-            let (bytes, string) = ctx.read_str()?;
+            let string = ctx.read_str()?;
             crate::params::validate_object_path(string)?;
-            Ok((bytes, params::Base::ObjectPath(string.into())))
+            Ok(params::Base::ObjectPath(string.into()))
         }
         signature::Base::Signature => {
-            let (bytes, string) = ctx.read_signature()?;
+            let string = ctx.read_signature()?;
             crate::params::validate_signature(string)?;
-            Ok((bytes, params::Base::Signature(string.to_owned())))
+            Ok(params::Base::Signature(string.to_owned()))
         }
     }
 }

--- a/rustbus/src/wire/unmarshal/param/base.rs
+++ b/rustbus/src/wire/unmarshal/param/base.rs
@@ -3,41 +3,32 @@
 use crate::params;
 use crate::signature;
 use crate::wire::errors::UnmarshalError;
-use crate::wire::unmarshal::UnmarshalContext;
 use crate::wire::unmarshal::UnmarshalResult;
-use crate::wire::util::*;
+use crate::wire::unmarshal_context::UnmarshalContext;
 
-pub fn unmarshal_base<'a>(
+pub fn unmarshal_base(
     typ: signature::Base,
     ctx: &mut UnmarshalContext,
-) -> UnmarshalResult<params::Base<'a>> {
-    let padding = ctx.align_to(typ.get_alignment())?;
-
-    let (bytes, param) = match typ {
+) -> UnmarshalResult<params::Base<'static>> {
+    match typ {
         signature::Base::Byte => {
-            if ctx.offset >= ctx.buf.len() {
-                return Err(UnmarshalError::NotEnoughBytes);
-            }
-            Ok((1, params::Base::Byte(ctx.buf[ctx.offset])))
+            let (bytes, val) = ctx.read_u8()?;
+            Ok((bytes, params::Base::Byte(val)))
         }
         signature::Base::Uint16 => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u16(slice, ctx.byteorder)?;
+            let (bytes, val) = ctx.read_u16()?;
             Ok((bytes, params::Base::Uint16(val)))
         }
         signature::Base::Int16 => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u16(slice, ctx.byteorder)?;
-            Ok((bytes, params::Base::Int16(val as i16)))
+            let (bytes, val) = ctx.read_i16()?;
+            Ok((bytes, params::Base::Int16(val)))
         }
         signature::Base::Uint32 => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u32(slice, ctx.byteorder)?;
+            let (bytes, val) = ctx.read_u32()?;
             Ok((bytes, params::Base::Uint32(val)))
         }
         signature::Base::UnixFd => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, idx) = parse_u32(slice, ctx.byteorder)?;
+            let (bytes, idx) = ctx.read_u32()?;
             if ctx.fds.len() <= idx as usize {
                 Err(UnmarshalError::BadFdIndex(idx as usize))
             } else {
@@ -46,28 +37,23 @@ pub fn unmarshal_base<'a>(
             }
         }
         signature::Base::Int32 => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u32(slice, ctx.byteorder)?;
-            Ok((bytes, params::Base::Int32(val as i32)))
+            let (bytes, val) = ctx.read_i32()?;
+            Ok((bytes, params::Base::Int32(val)))
         }
         signature::Base::Uint64 => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u64(slice, ctx.byteorder)?;
+            let (bytes, val) = ctx.read_u64()?;
             Ok((bytes, params::Base::Uint64(val)))
         }
         signature::Base::Int64 => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u64(slice, ctx.byteorder)?;
+            let (bytes, val) = ctx.read_i64()?;
             Ok((bytes, params::Base::Int64(val as i64)))
         }
         signature::Base::Double => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u64(slice, ctx.byteorder)?;
+            let (bytes, val) = ctx.read_u64()?;
             Ok((bytes, params::Base::Double(val)))
         }
         signature::Base::Boolean => {
-            let slice = &ctx.buf[ctx.offset..];
-            let (bytes, val) = parse_u32(slice, ctx.byteorder)?;
+            let (bytes, val) = ctx.read_u32()?;
             match val {
                 0 => Ok((bytes, params::Base::Boolean(false))),
                 1 => Ok((bytes, params::Base::Boolean(true))),
@@ -75,20 +61,18 @@ pub fn unmarshal_base<'a>(
             }
         }
         signature::Base::String => {
-            let (bytes, string) = unmarshal_string(ctx.byteorder, &ctx.buf[ctx.offset..])?;
-            Ok((bytes, params::Base::String(string)))
+            let (bytes, string) = ctx.read_str()?;
+            Ok((bytes, params::Base::String(string.into())))
         }
         signature::Base::ObjectPath => {
-            let (bytes, string) = unmarshal_string(ctx.byteorder, &ctx.buf[ctx.offset..])?;
-            crate::params::validate_object_path(&string)?;
-            Ok((bytes, params::Base::ObjectPath(string)))
+            let (bytes, string) = ctx.read_str()?;
+            crate::params::validate_object_path(string)?;
+            Ok((bytes, params::Base::ObjectPath(string.into())))
         }
         signature::Base::Signature => {
-            let (bytes, string) = unmarshal_signature(&ctx.buf[ctx.offset..])?;
+            let (bytes, string) = ctx.read_signature()?;
             crate::params::validate_signature(string)?;
             Ok((bytes, params::Base::Signature(string.to_owned())))
         }
-    }?;
-    ctx.offset += bytes;
-    Ok((padding + bytes, param))
+    }
 }

--- a/rustbus/src/wire/unmarshal/param/base.rs
+++ b/rustbus/src/wire/unmarshal/param/base.rs
@@ -46,7 +46,7 @@ pub fn unmarshal_base(
         }
         signature::Base::Int64 => {
             let (bytes, val) = ctx.read_i64()?;
-            Ok((bytes, params::Base::Int64(val as i64)))
+            Ok((bytes, params::Base::Int64(val)))
         }
         signature::Base::Double => {
             let (bytes, val) = ctx.read_u64()?;

--- a/rustbus/src/wire/unmarshal/param/container.rs
+++ b/rustbus/src/wire/unmarshal/param/container.rs
@@ -24,8 +24,8 @@ pub fn unmarshal_with_sig(
     Ok((bytes, param))
 }
 
-pub fn unmarshal_variant<'a, 'e>(
-    ctx: &mut UnmarshalContext<'_, 'a>,
+pub fn unmarshal_variant(
+    ctx: &mut UnmarshalContext,
 ) -> UnmarshalResult<params::Variant<'static, 'static>> {
     let (sig_bytes_used, sig_str) = ctx.read_signature()?;
 

--- a/rustbus/src/wire/unmarshal/param/container.rs
+++ b/rustbus/src/wire/unmarshal/param/container.rs
@@ -4,8 +4,8 @@ use crate::params;
 use crate::signature;
 use crate::wire::errors::UnmarshalError;
 use crate::wire::unmarshal::base::unmarshal_base;
-use crate::wire::unmarshal_context::UnmarshalContext;
 use crate::wire::unmarshal::UnmarshalResult;
+use crate::wire::unmarshal_context::UnmarshalContext;
 
 pub fn unmarshal_with_sig(
     sig: &signature::Type,
@@ -35,7 +35,7 @@ pub fn unmarshal_variant(
         return Err(UnmarshalError::WrongSignature);
     }
     let sig = sig.remove(0);
-    
+
     let (param_bytes_used, param) = unmarshal_with_sig(&sig, ctx)?;
     Ok((
         sig_bytes_used + param_bytes_used,
@@ -52,7 +52,6 @@ pub fn unmarshal_container(
             let start_len = ctx.remainder().len();
 
             let (bytes_in_len, bytes_in_array) = ctx.read_u32()?;
-            
 
             ctx.align_to(elem_sig.get_alignment())?;
 
@@ -85,7 +84,7 @@ pub fn unmarshal_container(
             let mut bytes_used_counter = 0;
             while bytes_used_counter < bytes_in_dict as usize {
                 bytes_used_counter += ctx.align_to(8)?;
-                
+
                 let (key_bytes, key) = unmarshal_base(*key_sig, ctx)?;
                 bytes_used_counter += key_bytes;
 

--- a/rustbus/src/wire/unmarshal/param/container.rs
+++ b/rustbus/src/wire/unmarshal/param/container.rs
@@ -4,14 +4,13 @@ use crate::params;
 use crate::signature;
 use crate::wire::errors::UnmarshalError;
 use crate::wire::unmarshal::base::unmarshal_base;
-use crate::wire::unmarshal::UnmarshalContext;
+use crate::wire::unmarshal_context::UnmarshalContext;
 use crate::wire::unmarshal::UnmarshalResult;
-use crate::wire::util::*;
 
-pub fn unmarshal_with_sig<'a, 'e>(
+pub fn unmarshal_with_sig(
     sig: &signature::Type,
     ctx: &mut UnmarshalContext,
-) -> UnmarshalResult<params::Param<'a, 'e>> {
+) -> UnmarshalResult<params::Param<'static, 'static>> {
     let (bytes, param) = match &sig {
         signature::Type::Base(base) => {
             let (bytes, base) = unmarshal_base(*base, ctx)?;
@@ -26,9 +25,9 @@ pub fn unmarshal_with_sig<'a, 'e>(
 }
 
 pub fn unmarshal_variant<'a, 'e>(
-    ctx: &mut UnmarshalContext,
-) -> UnmarshalResult<params::Variant<'a, 'e>> {
-    let (sig_bytes_used, sig_str) = unmarshal_signature(&ctx.buf[ctx.offset..])?;
+    ctx: &mut UnmarshalContext<'_, 'a>,
+) -> UnmarshalResult<params::Variant<'static, 'static>> {
+    let (sig_bytes_used, sig_str) = ctx.read_signature()?;
 
     let mut sig = signature::Type::parse_description(sig_str)?;
     if sig.len() != 1 {
@@ -36,8 +35,7 @@ pub fn unmarshal_variant<'a, 'e>(
         return Err(UnmarshalError::WrongSignature);
     }
     let sig = sig.remove(0);
-    ctx.offset += sig_bytes_used;
-
+    
     let (param_bytes_used, param) = unmarshal_with_sig(&sig, ctx)?;
     Ok((
         sig_bytes_used + param_bytes_used,
@@ -45,33 +43,29 @@ pub fn unmarshal_variant<'a, 'e>(
     ))
 }
 
-pub fn unmarshal_container<'a, 'e>(
+pub fn unmarshal_container(
     typ: &signature::Container,
     ctx: &mut UnmarshalContext,
-) -> UnmarshalResult<params::Container<'a, 'e>> {
+) -> UnmarshalResult<params::Container<'static, 'static>> {
     let param = match typ {
         signature::Container::Array(elem_sig) => {
-            let start_offset = ctx.offset;
-            ctx.align_to(4)?;
+            let start_len = ctx.remainder().len();
 
-            let (_, bytes_in_array) = parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-            ctx.offset += 4;
+            let (bytes_in_len, bytes_in_array) = ctx.read_u32()?;
+            
 
             ctx.align_to(elem_sig.get_alignment())?;
 
             let mut elements = Vec::new();
             let mut bytes_used_counter = 0;
             while bytes_used_counter < bytes_in_array as usize {
-                if ctx.offset >= ctx.buf.len() {
-                    return Err(UnmarshalError::NotEnoughBytes);
-                }
-
                 let (bytes_used, element) = unmarshal_with_sig(elem_sig, ctx)?;
                 elements.push(element);
                 bytes_used_counter += bytes_used;
             }
 
-            let total_bytes_used = ctx.offset - start_offset;
+            let total_bytes_used = start_len - ctx.remainder().len();
+            debug_assert_eq!(total_bytes_used, bytes_used_counter + bytes_in_len);
             (
                 total_bytes_used,
                 params::Container::Array(params::Array {
@@ -81,25 +75,17 @@ pub fn unmarshal_container<'a, 'e>(
             )
         }
         signature::Container::Dict(key_sig, val_sig) => {
-            let start_offset = ctx.offset;
+            let start_len = ctx.remainder().len();
 
-            ctx.align_to(4)?;
-            let (_, bytes_in_dict) = parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-            ctx.offset += 4;
+            let (bytes_in_len, bytes_in_dict) = ctx.read_u32()?;
 
             ctx.align_to(8)?;
 
             let mut elements = std::collections::HashMap::new();
             let mut bytes_used_counter = 0;
             while bytes_used_counter < bytes_in_dict as usize {
-                if ctx.offset >= ctx.buf.len() {
-                    return Err(UnmarshalError::NotEnoughBytes);
-                }
-
-                let element_padding = align_offset(8, ctx.buf, ctx.offset)?;
-                bytes_used_counter += element_padding;
-                ctx.offset += element_padding;
-
+                bytes_used_counter += ctx.align_to(8)?;
+                
                 let (key_bytes, key) = unmarshal_base(*key_sig, ctx)?;
                 bytes_used_counter += key_bytes;
 
@@ -109,7 +95,8 @@ pub fn unmarshal_container<'a, 'e>(
                 elements.insert(key, val);
             }
 
-            let total_bytes_used = ctx.offset - start_offset;
+            let total_bytes_used = start_len - ctx.remainder().len();
+            debug_assert_eq!(total_bytes_used, bytes_used_counter + bytes_in_len);
             (
                 total_bytes_used,
                 params::Container::Dict(params::Dict {
@@ -120,7 +107,7 @@ pub fn unmarshal_container<'a, 'e>(
             )
         }
         signature::Container::Struct(sigs) => {
-            let start_offset = ctx.offset;
+            let start_len = ctx.remainder().len();
 
             ctx.align_to(8)?;
             let mut fields = Vec::new();
@@ -133,7 +120,7 @@ pub fn unmarshal_container<'a, 'e>(
                 let (_, field) = unmarshal_with_sig(field_sig, ctx)?;
                 fields.push(field);
             }
-            let total_bytes_used = ctx.offset - start_offset;
+            let total_bytes_used = start_len - ctx.remainder().len();
             (total_bytes_used, params::Container::Struct(fields))
         }
         signature::Container::Variant => {

--- a/rustbus/src/wire/unmarshal/param/container.rs
+++ b/rustbus/src/wire/unmarshal/param/container.rs
@@ -11,23 +11,23 @@ pub fn unmarshal_with_sig(
     sig: &signature::Type,
     ctx: &mut UnmarshalContext,
 ) -> UnmarshalResult<params::Param<'static, 'static>> {
-    let (bytes, param) = match &sig {
+    let param = match &sig {
         signature::Type::Base(base) => {
-            let (bytes, base) = unmarshal_base(*base, ctx)?;
-            (bytes, params::Param::Base(base))
+            let base = unmarshal_base(*base, ctx)?;
+            params::Param::Base(base)
         }
         signature::Type::Container(cont) => {
-            let (bytes, cont) = unmarshal_container(cont, ctx)?;
-            (bytes, params::Param::Container(cont))
+            let cont = unmarshal_container(cont, ctx)?;
+            params::Param::Container(cont)
         }
     };
-    Ok((bytes, param))
+    Ok(param)
 }
 
 pub fn unmarshal_variant(
     ctx: &mut UnmarshalContext,
 ) -> UnmarshalResult<params::Variant<'static, 'static>> {
-    let (sig_bytes_used, sig_str) = ctx.read_signature()?;
+    let sig_str = ctx.read_signature()?;
 
     let mut sig = signature::Type::parse_description(sig_str)?;
     if sig.len() != 1 {
@@ -36,11 +36,8 @@ pub fn unmarshal_variant(
     }
     let sig = sig.remove(0);
 
-    let (param_bytes_used, param) = unmarshal_with_sig(&sig, ctx)?;
-    Ok((
-        sig_bytes_used + param_bytes_used,
-        params::Variant { sig, value: param },
-    ))
+    let param = unmarshal_with_sig(&sig, ctx)?;
+    Ok(params::Variant { sig, value: param })
 }
 
 pub fn unmarshal_container(
@@ -49,65 +46,46 @@ pub fn unmarshal_container(
 ) -> UnmarshalResult<params::Container<'static, 'static>> {
     let param = match typ {
         signature::Container::Array(elem_sig) => {
-            let start_len = ctx.remainder().len();
-
-            let (bytes_in_len, bytes_in_array) = ctx.read_u32()?;
+            let bytes_in_array = ctx.read_u32()? as usize;
 
             ctx.align_to(elem_sig.get_alignment())?;
 
             let mut elements = Vec::new();
-            let mut bytes_used_counter = 0;
-            while bytes_used_counter < bytes_in_array as usize {
-                let (bytes_used, element) = unmarshal_with_sig(elem_sig, ctx)?;
+            let raw_elements = ctx.read_raw(bytes_in_array)?;
+            let mut ctx = UnmarshalContext::new(ctx.fds, ctx.byteorder, raw_elements, 0);
+            while !ctx.remainder().is_empty() {
+                let element = unmarshal_with_sig(elem_sig, &mut ctx)?;
                 elements.push(element);
-                bytes_used_counter += bytes_used;
             }
 
-            let total_bytes_used = start_len - ctx.remainder().len();
-            debug_assert_eq!(total_bytes_used, bytes_used_counter + bytes_in_len);
-            (
-                total_bytes_used,
-                params::Container::Array(params::Array {
-                    element_sig: elem_sig.as_ref().clone(),
-                    values: elements,
-                }),
-            )
+            params::Container::Array(params::Array {
+                element_sig: elem_sig.as_ref().clone(),
+                values: elements,
+            })
         }
         signature::Container::Dict(key_sig, val_sig) => {
-            let start_len = ctx.remainder().len();
-
-            let (bytes_in_len, bytes_in_dict) = ctx.read_u32()?;
+            let bytes_in_dict = ctx.read_u32()? as usize;
 
             ctx.align_to(8)?;
 
             let mut elements = std::collections::HashMap::new();
-            let mut bytes_used_counter = 0;
-            while bytes_used_counter < bytes_in_dict as usize {
-                bytes_used_counter += ctx.align_to(8)?;
+            let raw_elements = ctx.read_raw(bytes_in_dict)?;
+            let mut ctx = UnmarshalContext::new(ctx.fds, ctx.byteorder, raw_elements, 0);
+            while !ctx.remainder().is_empty() {
+                ctx.align_to(8)?;
 
-                let (key_bytes, key) = unmarshal_base(*key_sig, ctx)?;
-                bytes_used_counter += key_bytes;
-
-                let (val_bytes, val) = unmarshal_with_sig(val_sig, ctx)?;
-                bytes_used_counter += val_bytes;
-
+                let key = unmarshal_base(*key_sig, &mut ctx)?;
+                let val = unmarshal_with_sig(val_sig, &mut ctx)?;
                 elements.insert(key, val);
             }
 
-            let total_bytes_used = start_len - ctx.remainder().len();
-            debug_assert_eq!(total_bytes_used, bytes_used_counter + bytes_in_len);
-            (
-                total_bytes_used,
-                params::Container::Dict(params::Dict {
-                    key_sig: *key_sig,
-                    value_sig: val_sig.as_ref().clone(),
-                    map: elements,
-                }),
-            )
+            params::Container::Dict(params::Dict {
+                key_sig: *key_sig,
+                value_sig: val_sig.as_ref().clone(),
+                map: elements,
+            })
         }
         signature::Container::Struct(sigs) => {
-            let start_len = ctx.remainder().len();
-
             ctx.align_to(8)?;
             let mut fields = Vec::new();
 
@@ -116,15 +94,14 @@ pub fn unmarshal_container(
             }
 
             for field_sig in sigs.as_ref() {
-                let (_, field) = unmarshal_with_sig(field_sig, ctx)?;
+                let field = unmarshal_with_sig(field_sig, ctx)?;
                 fields.push(field);
             }
-            let total_bytes_used = start_len - ctx.remainder().len();
-            (total_bytes_used, params::Container::Struct(fields))
+            params::Container::Struct(fields)
         }
         signature::Container::Variant => {
-            let (bytes_used, variant) = unmarshal_variant(ctx)?;
-            (bytes_used, params::Container::Variant(Box::new(variant)))
+            let variant = unmarshal_variant(ctx)?;
+            params::Container::Variant(Box::new(variant))
         }
     };
     Ok(param)

--- a/rustbus/src/wire/unmarshal/param/container.rs
+++ b/rustbus/src/wire/unmarshal/param/container.rs
@@ -51,8 +51,7 @@ pub fn unmarshal_container(
             ctx.align_to(elem_sig.get_alignment())?;
 
             let mut elements = Vec::new();
-            let raw_elements = ctx.read_raw(bytes_in_array)?;
-            let mut ctx = UnmarshalContext::new(ctx.fds, ctx.byteorder, raw_elements, 0);
+            let mut ctx = ctx.sub_context(bytes_in_array)?;
             while !ctx.remainder().is_empty() {
                 let element = unmarshal_with_sig(elem_sig, &mut ctx)?;
                 elements.push(element);
@@ -69,8 +68,7 @@ pub fn unmarshal_container(
             ctx.align_to(8)?;
 
             let mut elements = std::collections::HashMap::new();
-            let raw_elements = ctx.read_raw(bytes_in_dict)?;
-            let mut ctx = UnmarshalContext::new(ctx.fds, ctx.byteorder, raw_elements, 0);
+            let mut ctx = ctx.sub_context(bytes_in_dict)?;
             while !ctx.remainder().is_empty() {
                 ctx.align_to(8)?;
 

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -58,7 +58,7 @@ pub use container::*;
 ///
 /// impl<'buf, 'fds> Unmarshal<'buf, 'fds> for MyStruct {
 ///    fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-///         let start_offset = ctx.offset;
+///         let start_len = ctx.remainder().len();
 ///         // check that we are aligned properly!
 ///         // This is necessary at the start of each struct! They need to be aligned to 8 bytes!
 ///         let padding = ctx.align_to(Self::alignment())?;
@@ -70,7 +70,7 @@ pub use container::*;
 ///         // ....
 ///         
 ///         //then report the total bytes used by unmarshalling this type (INCLUDING padding at the beginning!):
-///         let total_bytes = ctx.offset - start_offset;
+///         let total_bytes = start_len - ctx.remainder().len();
 ///         Ok((total_bytes, MyStruct{mycoolint}))
 ///     }
 /// }
@@ -119,7 +119,7 @@ pub use container::*;
 ///
 /// impl<'buf, 'fds> Unmarshal<'buf, 'fds> for MyStruct {
 ///    fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> UnmarshalResult<Self> {
-///         let start_offset = ctx.offset;
+///         let start_len = ctx.remainder().len();
 ///         // check that we are aligned properly
 ///         let padding = ctx.align_to(Self::alignment())?;
 ///
@@ -128,7 +128,7 @@ pub use container::*;
 ///         let unmarshalled_stuff = unmarshal_stuff_from_raw(&raw_data);
 ///
 ///         //then report the total bytes used by unmarshalling this type (INCLUDING padding at the beginning!):
-///         let total_bytes = ctx.offset - start_offset;
+///         let total_bytes = start_len - ctx.remainder().len();
 ///         Ok((total_bytes, MyStruct{mycoolint: unmarshalled_stuff}))
 ///     }
 /// }

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -451,5 +451,27 @@ mod test {
             var_map["8"].get().unwrap()
         );
         assert!(var_map["9"].get::<bool>().unwrap());
+
+        let mut body = MarshalledMessageBody::new();
+        let orig = (10u8, 100u32, 20u8, 200u64);
+        body.push_variant(&orig).unwrap();
+        let unmarshalled = body
+            .parser()
+            .get::<Variant>()
+            .unwrap()
+            .get::<(u8, u32, u8, u64)>()
+            .unwrap();
+        assert_eq!(orig, unmarshalled);
+
+        let mut body = MarshalledMessageBody::new();
+        let orig = (10u8, 100u32, SignatureWrapper::new("").unwrap(), 200u64);
+        body.push_variant(&orig).unwrap();
+        let unmarshalled = body
+            .parser()
+            .get::<Variant>()
+            .unwrap()
+            .get::<(u8, u32, SignatureWrapper<&str>, u64)>()
+            .unwrap();
+        assert_eq!(orig, unmarshalled);
     }
 }

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -310,12 +310,9 @@ mod test {
 
         original.marshal(ctx).unwrap();
 
-        let (_, map) = std::collections::HashMap::<u64, &str>::unmarshal(&mut UnmarshalContext::new(
-            ctx.fds,
-            ctx.byteorder,
-            ctx.buf,
-            0,
-        ))
+        let (_, map) = std::collections::HashMap::<u64, &str>::unmarshal(
+            &mut UnmarshalContext::new(ctx.fds, ctx.byteorder, ctx.buf, 0),
+        )
         .unwrap();
         assert_eq!(original, map);
 
@@ -354,12 +351,7 @@ mod test {
         );
         let (_, (p, s, _fd)) =
             <(ObjectPath<String>, SignatureWrapper<&str>, UnixFd) as Unmarshal>::unmarshal(
-                &mut UnmarshalContext::new(
-                    ctx.fds,
-                    ctx.byteorder,
-                    ctx.buf,
-                    0,
-                ),
+                &mut UnmarshalContext::new(ctx.fds, ctx.byteorder, ctx.buf, 0),
             )
             .unwrap();
 

--- a/rustbus/src/wire/unmarshal/traits.rs
+++ b/rustbus/src/wire/unmarshal/traits.rs
@@ -210,7 +210,7 @@ mod test {
         x(arg);
     }
 
-    pub fn roundtrip<'a, T>(original: T, fds: &'a mut Vec<UnixFd>, buf: &'a mut Vec<u8>)
+    fn roundtrip<'a, T>(original: T, fds: &'a mut Vec<UnixFd>, buf: &'a mut Vec<u8>)
     where
         T: Unmarshal<'a, 'a>,
         T: Marshal,
@@ -223,8 +223,8 @@ mod test {
 
         original
             .marshal(&mut MarshalContext {
-                buf: buf,
-                fds: fds,
+                buf,
+                fds,
                 byteorder,
             })
             .unwrap();
@@ -275,6 +275,18 @@ mod test {
         original.insert(0u64, "abc");
         original.insert(1u64, "dce");
         original.insert(2u64, "fgh");
+        roundtrip(original, &mut fds, &mut buf);
+
+        let mut original = std::collections::HashMap::new();
+        original.insert(0u8, "abc");
+        original.insert(1u8, "dce");
+        original.insert(2u8, "fgh");
+        roundtrip(original, &mut fds, &mut buf);
+
+        let mut original = std::collections::HashMap::new();
+        original.insert(0i16, "abc");
+        original.insert(1i16, "dce");
+        original.insert(2i16, "fgh");
         roundtrip(original, &mut fds, &mut buf);
 
         let orig = (30u8, true, 100u8, -123i32);

--- a/rustbus/src/wire/unmarshal/traits/base.rs
+++ b/rustbus/src/wire/unmarshal/traits/base.rs
@@ -2,84 +2,54 @@
 
 use crate::wire::errors::UnmarshalError;
 use crate::wire::unmarshal;
-use crate::wire::unmarshal::UnmarshalContext;
-use crate::wire::util;
+use crate::wire::unmarshal_context::UnmarshalContext;
 use crate::wire::ObjectPath;
 use crate::wire::SignatureWrapper;
-use crate::Signature;
 use crate::Unmarshal;
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u64 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u64(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_u64()
     }
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u32 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_u32()
     }
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u16 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u16(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_u16()
     }
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i64 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u64(&ctx.buf[ctx.offset..], ctx.byteorder)
-            .map(|(bytes, val)| (bytes, val as i64))?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_i64()
     }
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i32 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)
-            .map(|(bytes, val)| (bytes, val as i32))?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_i32()
     }
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for i16 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u16(&ctx.buf[ctx.offset..], ctx.byteorder)
-            .map(|(bytes, val)| (bytes, val as i16))?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_i16()
     }
 }
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u8 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        if ctx.offset >= ctx.buf.len() {
-            return Err(UnmarshalError::NotEnoughBytes);
-        }
-        let val = ctx.buf[ctx.offset];
-        ctx.offset += 1;
-        Ok((1, val))
+        ctx.read_u8()
     }
 }
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for bool {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u32(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-        ctx.offset += bytes;
+        let (bytes, val) = ctx.read_u32()?;
         match val {
-            0 => Ok((bytes + padding, false)),
-            1 => Ok((bytes + padding, true)),
+            0 => Ok((bytes, false)),
+            1 => Ok((bytes, true)),
             _ => Err(UnmarshalError::InvalidBoolean),
         }
     }
@@ -87,28 +57,20 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for bool {
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for f64 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::parse_u64(&ctx.buf[ctx.offset..], ctx.byteorder)?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, f64::from_bits(val)))
+        let (bytes, val) = ctx.read_u64()?;
+        Ok((bytes, f64::from_bits(val)))
     }
 }
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf str {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::unmarshal_str(ctx.byteorder, &ctx.buf[ctx.offset..])?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_str()
     }
 }
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for String {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let padding = ctx.align_to(Self::alignment())?;
-        let (bytes, val) = util::unmarshal_string(ctx.byteorder, &ctx.buf[ctx.offset..])?;
-        ctx.offset += bytes;
-        Ok((bytes + padding, val))
+        ctx.read_str().map(|(bytes, val)| (bytes, val.to_owned()))
     }
 }
 
@@ -116,9 +78,7 @@ impl<'buf, 'fds, S: AsRef<str> + From<&'buf str> + Unmarshal<'buf, 'fds>> Unmars
     for SignatureWrapper<S>
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        // No alignment needed. Signature is aligned to 1
-        let (bytes, val) = util::unmarshal_signature(&ctx.buf[ctx.offset..])?;
-        ctx.offset += bytes;
+        let (bytes, val) = ctx.read_signature()?;
         let sig = SignatureWrapper::new(val.into())?;
         Ok((bytes, sig))
     }

--- a/rustbus/src/wire/unmarshal/traits/base.rs
+++ b/rustbus/src/wire/unmarshal/traits/base.rs
@@ -46,10 +46,10 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for u8 {
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for bool {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let (bytes, val) = ctx.read_u32()?;
+        let val = ctx.read_u32()?;
         match val {
-            0 => Ok((bytes, false)),
-            1 => Ok((bytes, true)),
+            0 => Ok(false),
+            1 => Ok(true),
             _ => Err(UnmarshalError::InvalidBoolean),
         }
     }
@@ -57,8 +57,8 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for bool {
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for f64 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let (bytes, val) = ctx.read_u64()?;
-        Ok((bytes, f64::from_bits(val)))
+        let val = ctx.read_u64()?;
+        Ok(f64::from_bits(val))
     }
 }
 
@@ -70,7 +70,7 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf str {
 
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for String {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        ctx.read_str().map(|(bytes, val)| (bytes, val.to_owned()))
+        ctx.read_str().map(|val| val.to_owned())
     }
 }
 
@@ -78,16 +78,16 @@ impl<'buf, 'fds, S: AsRef<str> + From<&'buf str> + Unmarshal<'buf, 'fds>> Unmars
     for SignatureWrapper<S>
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let (bytes, val) = ctx.read_signature()?;
+        let val = ctx.read_signature()?;
         let sig = SignatureWrapper::new(val.into())?;
-        Ok((bytes, sig))
+        Ok(sig)
     }
 }
 
 impl<'buf, 'fds, S: AsRef<str> + Unmarshal<'buf, 'fds>> Unmarshal<'buf, 'fds> for ObjectPath<S> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let (bytes, val) = <S as Unmarshal>::unmarshal(ctx)?;
+        let val = <S as Unmarshal>::unmarshal(ctx)?;
         let path = ObjectPath::new(val)?;
-        Ok((bytes, path))
+        Ok(path)
     }
 }

--- a/rustbus/src/wire/unmarshal/traits/base.rs
+++ b/rustbus/src/wire/unmarshal/traits/base.rs
@@ -62,8 +62,8 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for f64 {
     }
 }
 
-impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf str {
-    fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
+impl<'buf> Unmarshal<'buf, '_> for &'buf str {
+    fn unmarshal(ctx: &mut UnmarshalContext<'_, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         ctx.read_str()
     }
 }

--- a/rustbus/src/wire/unmarshal/traits/container.rs
+++ b/rustbus/src/wire/unmarshal/traits/container.rs
@@ -4,8 +4,7 @@ use crate::signature;
 use crate::wire::errors::UnmarshalError;
 use crate::wire::marshal::traits::SignatureBuffer;
 use crate::wire::unmarshal;
-use crate::wire::unmarshal::UnmarshalContext;
-use crate::wire::util;
+use crate::wire::unmarshal_context::UnmarshalContext;
 use crate::ByteOrder;
 use crate::Signature;
 use crate::Unmarshal;
@@ -28,14 +27,14 @@ where
     E2: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let start_offset = ctx.offset;
+        let start_len = ctx.remainder().len();
         ctx.align_to(8)?;
         let (_bytes, val1) = E1::unmarshal(ctx)?;
 
         ctx.align_to(E2::alignment())?;
         let (_bytes, val2) = E2::unmarshal(ctx)?;
 
-        let total_bytes = ctx.offset - start_offset;
+        let total_bytes = start_len - ctx.remainder().len();
         Ok((total_bytes, (val1, val2)))
     }
 }
@@ -47,18 +46,19 @@ where
     E3: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let start_offset = ctx.offset;
+        let start_len = ctx.remainder().len();
 
         ctx.align_to(8)?;
         let (_bytes, val1) = E1::unmarshal(ctx)?;
-
+        
         ctx.align_to(E2::alignment())?;
         let (_bytes, val2) = E2::unmarshal(ctx)?;
-
+        eprintln!("C");
+        
         ctx.align_to(E3::alignment())?;
         let (_bytes, val3) = E3::unmarshal(ctx)?;
-
-        let total_bytes = ctx.offset - start_offset;
+        
+        let total_bytes = start_len - ctx.remainder().len();
         Ok((total_bytes, (val1, val2, val3)))
     }
 }
@@ -71,7 +71,7 @@ where
     E4: Unmarshal<'buf, 'fds> + Sized,
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let start_offset = ctx.offset;
+        let start_len = ctx.remainder().len();
 
         ctx.align_to(8)?;
         let (_bytes, val1) = E1::unmarshal(ctx)?;
@@ -82,10 +82,11 @@ where
         ctx.align_to(E3::alignment())?;
         let (_bytes, val3) = E3::unmarshal(ctx)?;
 
+
         ctx.align_to(E4::alignment())?;
         let (_bytes, val4) = E4::unmarshal(ctx)?;
 
-        let total_bytes = ctx.offset - start_offset;
+        let total_bytes = start_len - ctx.remainder().len();
         Ok((total_bytes, (val1, val2, val3, val4)))
     }
 }
@@ -130,14 +131,9 @@ impl<E: Signature + Clone> Signature for Cow<'_, [E]> {
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for &'buf [u8] {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let padding = ctx.align_to(Self::alignment())?;
-        let (_, bytes_in_array) = u32::unmarshal(ctx)?;
+        let (elemtes_bytes_used, elements) = ctx.read_u8_slice()?;
 
-        let elements = &ctx.buf[ctx.offset..ctx.offset + bytes_in_array as usize];
-        ctx.offset += bytes_in_array as usize;
-
-        let total_bytes_used = padding + 4 + bytes_in_array as usize;
-
-        Ok((total_bytes_used, elements))
+        Ok((padding + elemtes_bytes_used, elements))
     }
 }
 
@@ -147,9 +143,8 @@ unsafe fn unmarshal_slice<'a, 'buf, 'fds, E>(
 where
     E: Unmarshal<'buf, 'fds>, //+ 'fds + 'buf
 {
-    let start_offset = ctx.offset;
-    ctx.align_to(4)?;
-    let (_, bytes_in_array) = u32::unmarshal(ctx)?;
+    let start_len = ctx.remainder().len();
+    let (_, bytes_in_array) = ctx.read_u32()?;
     let bytes_in_array = bytes_in_array as usize;
     let alignment = E::alignment();
     ctx.align_to(alignment)?;
@@ -158,22 +153,14 @@ where
     if bytes_in_array % alignment != 0 {
         return Err(UnmarshalError::NotAllBytesUsed);
     }
-    // Start at offset
-    let start_slice = &ctx.buf[ctx.offset..];
-    // Check that the buffer contains enough bytes
-    if bytes_in_array > start_slice.len() {
-        return Err(UnmarshalError::NotEnoughBytes);
-    }
-    // limit the source slice to assert that the memory access will be valid
-    let content_slice = &start_slice[..bytes_in_array];
+    let (_, content_slice) = ctx.read_raw(bytes_in_array)?;
 
     // cast the slice from u8 to the target type
     let elem_cnt = bytes_in_array / alignment;
     let ptr = content_slice.as_ptr().cast::<E>();
     let slice = std::slice::from_raw_parts(ptr, elem_cnt);
 
-    ctx.offset += bytes_in_array;
-    Ok((ctx.offset - start_offset, slice))
+    Ok((start_len - ctx.remainder().len(), slice))
 }
 impl<'buf, 'fds, E: Unmarshal<'buf, 'fds> + Clone> Unmarshal<'buf, 'fds> for Cow<'buf, [E]> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
@@ -201,7 +188,7 @@ impl<'buf, 'fds, E: Unmarshal<'buf, 'fds>> Unmarshal<'buf, 'fds> for Vec<E> {
                 return Ok((used, ret));
             }
         }
-        let start_offset = ctx.offset;
+        let start_len = ctx.remainder().len();
         ctx.align_to(4)?;
         let (_, bytes_in_array) = u32::unmarshal(ctx)?;
 
@@ -210,21 +197,14 @@ impl<'buf, 'fds, E: Unmarshal<'buf, 'fds>> Unmarshal<'buf, 'fds> for Vec<E> {
         let mut elements = Vec::new();
         let mut bytes_used_counter = 0;
         while bytes_used_counter < bytes_in_array as usize {
-            if ctx.offset >= ctx.buf.len() {
-                return Err(UnmarshalError::NotEnoughBytes);
-            }
-
-            let elem_padding = util::align_offset(E::alignment(), ctx.buf, ctx.offset)?;
-
-            bytes_used_counter += elem_padding;
-            ctx.offset += elem_padding;
+            bytes_used_counter += ctx.align_to(E::alignment())?;
 
             let (bytes_used, element) = E::unmarshal(ctx)?;
             elements.push(element);
             bytes_used_counter += bytes_used;
         }
 
-        let total_bytes_used = ctx.offset - start_offset;
+        let total_bytes_used = start_len - ctx.remainder().len();
 
         Ok((total_bytes_used, elements))
     }
@@ -234,7 +214,7 @@ impl<'buf, 'fds, K: Unmarshal<'buf, 'fds> + std::hash::Hash + Eq, V: Unmarshal<'
     Unmarshal<'buf, 'fds> for std::collections::HashMap<K, V>
 {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let start_offset = ctx.offset;
+        let start_len = ctx.remainder().len();
         ctx.align_to(4)?;
         let (_, bytes_in_array) = u32::unmarshal(ctx)?;
 
@@ -244,28 +224,20 @@ impl<'buf, 'fds, K: Unmarshal<'buf, 'fds> + std::hash::Hash + Eq, V: Unmarshal<'
         let mut map = std::collections::HashMap::new();
         let mut bytes_used_counter = 0;
         while bytes_used_counter < bytes_in_array as usize {
-            if ctx.offset >= ctx.buf.len() {
-                return Err(UnmarshalError::NotEnoughBytes);
-            }
-
-            let elem_padding = util::align_offset(8, ctx.buf, ctx.offset)?;
-            bytes_used_counter += elem_padding;
-            ctx.offset += elem_padding;
-
+            // Always align to 8
+            bytes_used_counter += ctx.align_to(8)?;
             let (key_bytes_used, key) = K::unmarshal(ctx)?;
             bytes_used_counter += key_bytes_used;
 
-            let val_padding = util::align_offset(V::alignment(), ctx.buf, ctx.offset)?;
-            bytes_used_counter += val_padding;
-            ctx.offset += val_padding;
-
+            //Align to value
+            bytes_used_counter += ctx.align_to(V::alignment())?;
             let (val_bytes_used, val) = V::unmarshal(ctx)?;
             bytes_used_counter += val_bytes_used;
 
             map.insert(key, val);
         }
 
-        let total_bytes_used = ctx.offset - start_offset;
+        let total_bytes_used = start_len - ctx.remainder().len();
 
         Ok((total_bytes_used, map))
     }
@@ -294,12 +266,7 @@ impl<'buf, 'fds> Variant<'fds, 'buf> {
         if self.sig != T::signature() {
             return Err(UnmarshalError::WrongSignature);
         }
-        let mut ctx = UnmarshalContext {
-            byteorder: self.byteorder,
-            offset: self.offset,
-            buf: self.buf,
-            fds: self.fds,
-        };
+        let mut ctx = UnmarshalContext::new(self.fds, self.byteorder, self.buf, self.offset);
         T::unmarshal(&mut ctx).map(|r| r.1)
     }
 }
@@ -320,9 +287,8 @@ impl Signature for Variant<'_, '_> {
 }
 impl<'buf, 'fds> Unmarshal<'buf, 'fds> for Variant<'fds, 'buf> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
-        let start_offset = ctx.offset;
-        let (sig_bytes, desc) = util::unmarshal_signature(&ctx.buf[ctx.offset..])?;
-        ctx.offset += sig_bytes;
+        let start_len = ctx.remainder().len();
+        let (_, desc) = ctx.read_signature()?;
 
         let mut sigs = match signature::Type::parse_description(desc) {
             Ok(sigs) => sigs,
@@ -335,24 +301,23 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for Variant<'fds, 'buf> {
 
         ctx.align_to(sig.get_alignment())?;
 
-        let start_loc = ctx.offset;
-
         let val_bytes = crate::wire::validate_raw::validate_marshalled(
             ctx.byteorder,
-            ctx.offset,
-            ctx.buf,
+            0,
+            ctx.remainder(),
             &sig,
         )
         .map_err(|e| e.1)?;
-        ctx.offset += val_bytes;
 
-        let total_bytes = ctx.offset - start_offset;
+        let (_, raw_content) = ctx.read_raw(val_bytes)?;
+
+        let total_bytes = start_len - ctx.remainder().len();
         Ok((
             total_bytes,
             Variant {
                 sig,
-                buf: &ctx.buf[..ctx.offset],
-                offset: start_loc,
+                buf: raw_content,
+                offset: 0,
                 byteorder: ctx.byteorder,
                 fds: ctx.fds,
             },

--- a/rustbus/src/wire/unmarshal/traits/container.rs
+++ b/rustbus/src/wire/unmarshal/traits/container.rs
@@ -311,4 +311,23 @@ mod tests {
             .unwrap();
         assert_eq!(variant.get::<u8>().unwrap(), 42);
     }
+
+    #[test]
+    fn array() {
+        let mut m = MarshalledMessageBody::new();
+        m.push_param([0u8, 1, 2, 3, 4, 5]).unwrap(); // Array by value
+        m.push_param(0u8).unwrap();
+        m.push_param(-10i16).unwrap();
+        m.push_param(&[0u8, 1, 2, 3, 4, 5, 6]).unwrap(); // Array as ref
+        m.push_param(-2000i16).unwrap();
+        m.push_param(&[0u8, 1, 2, 3, 4, 5, 6, 7][..]).unwrap(); // Slice
+
+        let mut parser = m.parser();
+        assert_eq!(parser.get::<&[u8]>().unwrap(), &[0, 1, 2, 3, 4, 5]);
+        assert_eq!(parser.get::<u8>().unwrap(), 0);
+        assert_eq!(parser.get::<i16>().unwrap(), -10);
+        assert_eq!(parser.get::<&[u8]>().unwrap(), &[0, 1, 2, 3, 4, 5, 6]);
+        assert_eq!(parser.get::<i16>().unwrap(), -2000);
+        assert_eq!(parser.get::<&[u8]>().unwrap(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+    }
 }

--- a/rustbus/src/wire/unmarshal/traits/container.rs
+++ b/rustbus/src/wire/unmarshal/traits/container.rs
@@ -269,9 +269,8 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for Variant<'fds, 'buf> {
     fn unmarshal(ctx: &mut UnmarshalContext<'fds, 'buf>) -> unmarshal::UnmarshalResult<Self> {
         let desc = ctx.read_signature()?;
 
-        let mut sigs = match signature::Type::parse_description(desc) {
-            Ok(sigs) => sigs,
-            Err(_) => return Err(UnmarshalError::WrongSignature),
+        let Ok(mut sigs) = signature::Type::parse_description(desc) else {
+            return Err(UnmarshalError::WrongSignature);
         };
         if sigs.len() != 1 {
             return Err(UnmarshalError::WrongSignature);

--- a/rustbus/src/wire/unmarshal/traits/container.rs
+++ b/rustbus/src/wire/unmarshal/traits/container.rs
@@ -50,14 +50,14 @@ where
 
         ctx.align_to(8)?;
         let (_bytes, val1) = E1::unmarshal(ctx)?;
-        
+
         ctx.align_to(E2::alignment())?;
         let (_bytes, val2) = E2::unmarshal(ctx)?;
         eprintln!("C");
-        
+
         ctx.align_to(E3::alignment())?;
         let (_bytes, val3) = E3::unmarshal(ctx)?;
-        
+
         let total_bytes = start_len - ctx.remainder().len();
         Ok((total_bytes, (val1, val2, val3)))
     }
@@ -81,7 +81,6 @@ where
 
         ctx.align_to(E3::alignment())?;
         let (_bytes, val3) = E3::unmarshal(ctx)?;
-
 
         ctx.align_to(E4::alignment())?;
         let (_bytes, val4) = E4::unmarshal(ctx)?;
@@ -301,13 +300,9 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for Variant<'fds, 'buf> {
 
         ctx.align_to(sig.get_alignment())?;
 
-        let val_bytes = crate::wire::validate_raw::validate_marshalled(
-            ctx.byteorder,
-            0,
-            ctx.remainder(),
-            &sig,
-        )
-        .map_err(|e| e.1)?;
+        let val_bytes =
+            crate::wire::validate_raw::validate_marshalled(ctx.byteorder, 0, ctx.remainder(), &sig)
+                .map_err(|e| e.1)?;
 
         let (_, raw_content) = ctx.read_raw(val_bytes)?;
 

--- a/rustbus/src/wire/unmarshal/traits/container.rs
+++ b/rustbus/src/wire/unmarshal/traits/container.rs
@@ -296,14 +296,12 @@ mod tests {
     use crate::message_builder::MarshalledMessageBody;
 
     #[test]
-    fn todo_name() {
+    fn variant_with_sig() {
         let mut m = MarshalledMessageBody::new();
         m.push_param("test.interface").unwrap();
         m.push_param("test_property").unwrap();
         m.push_param(crate::wire::marshal::traits::Variant(42u8))
             .unwrap();
-
-        eprintln!("Buffer: {:?}", m.get_buf());
 
         let mut parser = m.parser();
         assert_eq!(parser.get::<&str>().unwrap(), "test.interface");

--- a/rustbus/src/wire/unmarshal_context.rs
+++ b/rustbus/src/wire/unmarshal_context.rs
@@ -58,10 +58,10 @@ impl<'fds, 'buf> UnmarshalContext<'fds, 'buf> {
     }
 
     pub fn read_u16(&mut self) -> UnmarshalResult<u16> {
-        self.align_to(2)?;
+        let padding = self.align_to(2)?;
         let (consumed_value, value) = parse_u16(self.remainder(), self.byteorder)?;
         self.offset += consumed_value;
-        Ok((consumed_value, value))
+        Ok((consumed_value + padding, value))
     }
 
     pub fn read_i32(&mut self) -> UnmarshalResult<i32> {
@@ -70,10 +70,10 @@ impl<'fds, 'buf> UnmarshalContext<'fds, 'buf> {
     }
 
     pub fn read_u32(&mut self) -> UnmarshalResult<u32> {
-        self.align_to(4)?;
+        let padding = self.align_to(4)?;
         let (consumed_value, value) = parse_u32(self.remainder(), self.byteorder)?;
         self.offset += consumed_value;
-        Ok((consumed_value, value))
+        Ok((consumed_value + padding, value))
     }
 
     pub fn read_i64(&mut self) -> UnmarshalResult<i64> {
@@ -82,17 +82,17 @@ impl<'fds, 'buf> UnmarshalContext<'fds, 'buf> {
     }
 
     pub fn read_u64(&mut self) -> UnmarshalResult<u64> {
-        self.align_to(8)?;
+        let padding = self.align_to(8)?;
         let (consumed_value, value) = parse_u64(self.remainder(), self.byteorder)?;
         self.offset += consumed_value;
-        Ok((consumed_value, value))
+        Ok((consumed_value + padding, value))
     }
 
     pub fn read_str(&mut self) -> UnmarshalResult<&'buf str> {
-        self.align_to(4)?;
+        let padding = self.align_to(4)?;
         let (consumed_value, value) = unmarshal_str(self.byteorder, &self.buf[self.offset..])?;
         self.offset += consumed_value;
-        Ok((consumed_value, value))
+        Ok((consumed_value + padding, value))
     }
 
     pub fn read_signature(&mut self) -> UnmarshalResult<&'buf str> {

--- a/rustbus/src/wire/unmarshal_context.rs
+++ b/rustbus/src/wire/unmarshal_context.rs
@@ -111,11 +111,11 @@ impl<'fds, 'buf> UnmarshalContext<'fds, 'buf> {
     }
 
     pub fn read_raw(&mut self, length: usize) -> UnmarshalResult<&'buf [u8]> {
-        if length as usize > self.remainder().len() {
+        if length > self.remainder().len() {
             return Err(UnmarshalError::NotEnoughBytes);
         }
 
-        let elements = &&self.buf[self.offset..][..length as usize];
+        let elements = &&self.buf[self.offset..][..length];
         self.offset += length;
 
         Ok((length, elements))

--- a/rustbus/src/wire/unmarshal_context.rs
+++ b/rustbus/src/wire/unmarshal_context.rs
@@ -1,0 +1,127 @@
+use crate::ByteOrder;
+
+use super::{
+    errors::UnmarshalError,
+    unmarshal::UnmarshalResult,
+    util::{parse_u16, parse_u32, parse_u64, unmarshal_signature, unmarshal_str},
+};
+
+pub struct UnmarshalContext<'fds, 'buf> {
+    pub fds: &'fds [crate::wire::UnixFd],
+    pub byteorder: ByteOrder,
+    buf: &'buf [u8],
+    offset: usize,
+}
+
+impl<'fds, 'buf> UnmarshalContext<'fds, 'buf> {
+    pub fn new(
+        fds: &'fds [crate::wire::UnixFd],
+        byteorder: ByteOrder,
+        buf: &'buf [u8],
+        offset: usize,
+    ) -> UnmarshalContext<'fds, 'buf> {
+        Self {
+            fds,
+            byteorder,
+            buf,
+            offset,
+        }
+    }
+
+    pub fn align_to(&mut self, alignment: usize) -> Result<usize, UnmarshalError> {
+        let padding = crate::wire::util::align_offset(alignment, self.buf, self.offset)?;
+
+        if self.offset + padding > self.buf.len() {
+            Err(UnmarshalError::NotEnoughBytes)
+        } else {
+            self.offset += padding;
+            Ok(padding)
+        }
+    }
+
+    pub fn remainder(&self) -> &[u8] {
+        &self.buf[self.offset..]
+    }
+
+    pub fn read_u8(&mut self) -> UnmarshalResult<u8> {
+        if self.remainder().is_empty() {
+            Err(UnmarshalError::NotEnoughBytes)
+        } else {
+            self.offset += 1;
+            Ok((1, self.buf[self.offset - 1]))
+        }
+    }
+
+    pub fn read_i16(&mut self) -> UnmarshalResult<i16> {
+        self.read_u16()
+            .map(|(consumed, value)| (consumed, value as i16))
+    }
+
+    pub fn read_u16(&mut self) -> UnmarshalResult<u16> {
+        self.align_to(2)?;
+        let (consumed_value, value) = parse_u16(self.remainder(), self.byteorder)?;
+        self.offset += consumed_value;
+        Ok((consumed_value, value))
+    }
+
+    pub fn read_i32(&mut self) -> UnmarshalResult<i32> {
+        self.read_u32()
+            .map(|(consumed, value)| (consumed, value as i32))
+    }
+
+    pub fn read_u32(&mut self) -> UnmarshalResult<u32> {
+        self.align_to(4)?;
+        let (consumed_value, value) = parse_u32(self.remainder(), self.byteorder)?;
+        self.offset += consumed_value;
+        Ok((consumed_value, value))
+    }
+
+    pub fn read_i64(&mut self) -> UnmarshalResult<i64> {
+        self.read_u64()
+            .map(|(consumed, value)| (consumed, value as i64))
+    }
+
+    pub fn read_u64(&mut self) -> UnmarshalResult<u64> {
+        self.align_to(8)?;
+        let (consumed_value, value) = parse_u64(self.remainder(), self.byteorder)?;
+        self.offset += consumed_value;
+        Ok((consumed_value, value))
+    }
+
+    pub fn read_str(&mut self) -> UnmarshalResult<&'buf str> {
+        self.align_to(4)?;
+        let (consumed_value, value) = unmarshal_str(self.byteorder, &self.buf[self.offset..])?;
+        self.offset += consumed_value;
+        Ok((consumed_value, value))
+    }
+
+    pub fn read_signature(&mut self) -> UnmarshalResult<&'buf str> {
+        let (consumed_value, value) = unmarshal_signature(&self.buf[self.offset..])?;
+        self.offset += consumed_value;
+        Ok((consumed_value, value))
+    }
+
+    pub fn read_u8_slice(&mut self) -> UnmarshalResult<&'buf [u8]> {
+        let (bytes_in_len, bytes_in_array) = self.read_u32()?;
+
+        let (_, elements) = self.read_raw(bytes_in_array as usize)?;
+
+        let total_bytes_used = bytes_in_len + bytes_in_array as usize;
+        Ok((total_bytes_used, elements))
+    }
+
+    pub fn read_raw(&mut self, length: usize) -> UnmarshalResult<&'buf [u8]> {
+        if length as usize > self.remainder().len() {
+            return Err(UnmarshalError::NotEnoughBytes);
+        }
+
+        let elements = &&self.buf[self.offset..][..length as usize];
+        self.offset += length;
+
+        Ok((length, elements))
+    }
+
+    pub fn reset(&mut self, reset_by: usize) {
+        self.offset -= reset_by;
+    }
+}

--- a/rustbus/src/wire/util.rs
+++ b/rustbus/src/wire/util.rs
@@ -210,8 +210,8 @@ pub fn unmarshal_signature(buf: &[u8]) -> UnmarshalResult<&str> {
         return Err(UnmarshalError::NotEnoughBytes);
     }
     let sig_buf = &buf[1..][..len];
-    let string = std::str::from_utf8(sig_buf)
-        .map_err(|_| crate::params::validation::Error::InvalidUtf8)?;
+    let string =
+        std::str::from_utf8(sig_buf).map_err(|_| crate::params::validation::Error::InvalidUtf8)?;
     Ok((len + 2, string))
 }
 

--- a/rustbus/src/wire/util.rs
+++ b/rustbus/src/wire/util.rs
@@ -209,8 +209,8 @@ pub fn unmarshal_signature(buf: &[u8]) -> UnmarshalResult<&str> {
     if buf.len() < len + 2 {
         return Err(UnmarshalError::NotEnoughBytes);
     }
-    let sig_buf = &buf[1..];
-    let string = std::str::from_utf8(&sig_buf[..len])
+    let sig_buf = &buf[1..][..len];
+    let string = std::str::from_utf8(sig_buf)
         .map_err(|_| crate::params::validation::Error::InvalidUtf8)?;
     Ok((len + 2, string))
 }

--- a/rustbus/src/wire/util.rs
+++ b/rustbus/src/wire/util.rs
@@ -147,7 +147,7 @@ pub fn parse_u64(number: &[u8], byteorder: ByteOrder) -> UnmarshalResult<u64> {
                 + ((number[0] as u64) << 56)
         }
     };
-    Ok((8, val))
+    Ok(val)
 }
 
 pub fn parse_u32(number: &[u8], byteorder: ByteOrder) -> UnmarshalResult<u32> {
@@ -168,7 +168,7 @@ pub fn parse_u32(number: &[u8], byteorder: ByteOrder) -> UnmarshalResult<u32> {
                 + ((number[0] as u32) << 24)
         }
     };
-    Ok((4, val))
+    Ok(val)
 }
 
 pub fn parse_u16(number: &[u8], byteorder: ByteOrder) -> UnmarshalResult<u16> {
@@ -179,7 +179,7 @@ pub fn parse_u16(number: &[u8], byteorder: ByteOrder) -> UnmarshalResult<u16> {
         ByteOrder::LittleEndian => (number[0] as u16) + ((number[1] as u16) << 8),
         ByteOrder::BigEndian => (number[1] as u16) + ((number[0] as u16) << 8),
     };
-    Ok((2, val))
+    Ok(val)
 }
 
 pub fn align_offset(align_to: usize, buf: &[u8], offset: usize) -> Result<usize, UnmarshalError> {
@@ -201,7 +201,7 @@ pub fn align_offset(align_to: usize, buf: &[u8], offset: usize) -> Result<usize,
     Ok(padding_delete)
 }
 
-pub fn unmarshal_signature(buf: &[u8]) -> UnmarshalResult<&str> {
+pub fn unmarshal_signature(buf: &[u8]) -> UnmarshalResult<(usize, &str)> {
     if buf.is_empty() {
         return Err(UnmarshalError::NotEnoughBytes);
     }
@@ -215,13 +215,16 @@ pub fn unmarshal_signature(buf: &[u8]) -> UnmarshalResult<&str> {
     Ok((len + 2, string))
 }
 
-pub fn unmarshal_string(byteorder: ByteOrder, buf: &[u8]) -> UnmarshalResult<String> {
+pub fn unmarshal_string(byteorder: ByteOrder, buf: &[u8]) -> UnmarshalResult<(usize, String)> {
     let (bytes, string) = unmarshal_str(byteorder, buf)?;
     Ok((bytes, string.into()))
 }
 
-pub fn unmarshal_str<'r, 'a: 'r>(byteorder: ByteOrder, buf: &'a [u8]) -> UnmarshalResult<&'r str> {
-    let len = parse_u32(buf, byteorder)?.1 as usize;
+pub fn unmarshal_str<'r, 'a: 'r>(
+    byteorder: ByteOrder,
+    buf: &'a [u8],
+) -> UnmarshalResult<(usize, &'r str)> {
+    let len = parse_u32(buf, byteorder)? as usize;
     if buf.len() < len + 5 {
         return Err(UnmarshalError::NotEnoughBytes);
     }

--- a/rustbus/src/wire/validate_raw.rs
+++ b/rustbus/src/wire/validate_raw.rs
@@ -92,7 +92,7 @@ pub fn validate_marshalled_base(
             }
             let offset = offset + padding;
             let slice = &buf[offset..offset + 4];
-            let (_, val) =
+            let val =
                 crate::wire::util::parse_u32(slice, byteorder).map_err(|err| (offset, err))?;
             match val {
                 0 => Ok(4 + padding),
@@ -134,7 +134,7 @@ pub fn validate_marshalled_container(
         signature::Container::Array(elem_sig) => {
             let padding = util::align_offset(4, buf, offset).map_err(|err| (offset, err))?;
             let offset = offset + padding;
-            let (_, bytes_in_array) =
+            let bytes_in_array =
                 util::parse_u32(&buf[offset..], byteorder).map_err(|err| (offset, err))?;
             let offset = offset + 4;
 
@@ -176,7 +176,7 @@ pub fn validate_marshalled_container(
         signature::Container::Dict(key_sig, val_sig) => {
             let padding = util::align_offset(4, buf, offset).map_err(|err| (offset, err))?;
             let offset = offset + padding;
-            let (_, bytes_in_dict) =
+            let bytes_in_dict =
                 util::parse_u32(&buf[offset..], byteorder).map_err(|err| (offset, err))?;
             let offset = offset + 4;
 

--- a/rustbus/src/wire/variant_macros.rs
+++ b/rustbus/src/wire/variant_macros.rs
@@ -160,14 +160,10 @@ fn test_variant_sig_macro() {
     )
     .unwrap();
 
-    let (bytes, (uv1, uv2, uv3)) =
-        <(MyVariant, MyVariant, MyVariant) as Unmarshal>::unmarshal(&mut UnmarshalContext::new(
-            ctx.fds,
-            ctx.byteorder,
-            ctx.buf,
-            0,
-        ))
-        .unwrap();
+    let (bytes, (uv1, uv2, uv3)) = <(MyVariant, MyVariant, MyVariant) as Unmarshal>::unmarshal(
+        &mut UnmarshalContext::new(ctx.fds, ctx.byteorder, ctx.buf, 0),
+    )
+    .unwrap();
     assert_eq!(uv1, v1);
     assert_ne!(uv1, v2);
     assert_ne!(uv1, v3);
@@ -209,12 +205,7 @@ fn test_variant_sig_macro() {
     (&v1, &v2, &v3, &v4).marshal(ctx).unwrap();
     let (_bytes, (uv1, uv2, uv3, uv4)) =
         <(MyVariant2, MyVariant2, MyVariant2, MyVariant2) as Unmarshal>::unmarshal(
-            &mut UnmarshalContext::new( 
-                ctx.fds,
-                ctx.byteorder,
-                ctx.buf,
-                0,
-            ),
+            &mut UnmarshalContext::new(ctx.fds, ctx.byteorder, ctx.buf, 0),
         )
         .unwrap();
     assert_eq!(uv1, v1);
@@ -419,12 +410,7 @@ fn test_variant_var_macro() {
 
     let (bytes, (uv1, uv2, uv3, uv4)) =
         <(MyVariant, MyVariant, MyVariant, MyVariant) as Unmarshal>::unmarshal(
-            &mut UnmarshalContext::new(
-                ctx.fds,
-                ctx.byteorder,
-                ctx.buf,
-                0,
-            ),
+            &mut UnmarshalContext::new(ctx.fds, ctx.byteorder, ctx.buf, 0),
         )
         .unwrap();
     assert!(match uv1 {
@@ -447,7 +433,7 @@ fn test_variant_var_macro() {
     eprintln!("Buffer: {:?}", ctx.buf);
     eprintln!("Buffer: {:?}", &ctx.buf[bytes..]);
 
-    let (_bytes, uv4) = MyVariant::unmarshal(&mut UnmarshalContext::new (
+    let (_bytes, uv4) = MyVariant::unmarshal(&mut UnmarshalContext::new(
         ctx.fds,
         ctx.byteorder,
         ctx.buf,
@@ -480,12 +466,7 @@ fn test_variant_var_macro() {
     (&v1, &v2, &v3, &v4).marshal(ctx).unwrap();
     let (_bytes, (uv1, uv2, uv3, uv4)) =
         <(MyVariant2, MyVariant2, MyVariant2, MyVariant2) as Unmarshal>::unmarshal(
-            &mut UnmarshalContext::new(
-                ctx.fds,
-                ctx.byteorder,
-                ctx.buf,
-                0,
-            ),
+            &mut UnmarshalContext::new(ctx.fds, ctx.byteorder, ctx.buf, 0),
         )
         .unwrap();
     assert!(match uv1 {

--- a/rustbus/src/wire/wrapper_types/unixfd.rs
+++ b/rustbus/src/wire/wrapper_types/unixfd.rs
@@ -1,7 +1,7 @@
 use crate::wire::errors::{MarshalError, UnmarshalError};
 use crate::wire::marshal::traits::SignatureBuffer;
 use crate::wire::marshal::MarshalContext;
-use crate::wire::unmarshal::UnmarshalContext;
+use crate::wire::unmarshal_context::UnmarshalContext;
 use crate::{Marshal, Signature, Unmarshal};
 
 use std::io;

--- a/rustbus/src/wire/wrapper_types/unixfd.rs
+++ b/rustbus/src/wire/wrapper_types/unixfd.rs
@@ -1,4 +1,4 @@
-use crate::wire::errors::{MarshalError, UnmarshalError};
+use crate::wire::errors::MarshalError;
 use crate::wire::marshal::traits::SignatureBuffer;
 use crate::wire::marshal::MarshalContext;
 use crate::wire::unmarshal_context::UnmarshalContext;
@@ -191,14 +191,7 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for UnixFd {
     fn unmarshal(
         ctx: &mut UnmarshalContext<'fds, 'buf>,
     ) -> crate::wire::unmarshal::UnmarshalResult<Self> {
-        let idx = u32::unmarshal(ctx)?;
-
-        if ctx.fds.len() <= idx as usize {
-            Err(UnmarshalError::BadFdIndex(idx as usize))
-        } else {
-            let val = &ctx.fds[idx as usize];
-            Ok(val.clone())
-        }
+        ctx.read_unixfd()
     }
 }
 

--- a/rustbus/src/wire/wrapper_types/unixfd.rs
+++ b/rustbus/src/wire/wrapper_types/unixfd.rs
@@ -191,13 +191,13 @@ impl<'buf, 'fds> Unmarshal<'buf, 'fds> for UnixFd {
     fn unmarshal(
         ctx: &mut UnmarshalContext<'fds, 'buf>,
     ) -> crate::wire::unmarshal::UnmarshalResult<Self> {
-        let (bytes, idx) = u32::unmarshal(ctx)?;
+        let idx = u32::unmarshal(ctx)?;
 
         if ctx.fds.len() <= idx as usize {
             Err(UnmarshalError::BadFdIndex(idx as usize))
         } else {
             let val = &ctx.fds[idx as usize];
-            Ok((bytes, val.clone()))
+            Ok(val.clone())
         }
     }
 }

--- a/rustbus_derive/Cargo.toml
+++ b/rustbus_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbus_derive"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Moritz Borcherding <moritz.borcherding@web.de>"]
 edition = "2018"
 license = "MIT"

--- a/rustbus_derive/src/structs.rs
+++ b/rustbus_derive/src/structs.rs
@@ -50,7 +50,7 @@ pub fn make_struct_unmarshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Unmarshal<'__internal_buf, '_> for #ident #typ_gen #clause_gen {
             #[inline]
-            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<(usize,Self), ::rustbus::wire::errors::UnmarshalError> {
+            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<Self, ::rustbus::wire::errors::UnmarshalError> {
                 #marshal
             }
         }
@@ -102,16 +102,14 @@ fn struct_field_unmarshal(fields: &syn::Fields) -> TokenStream {
     let field_types = fields.iter().map(|field| field.ty.to_token_stream());
 
     quote! {
-            let start_len = ctx.remainder().len();
             ctx.align_to(8)?;
 
             let this = Self{
                 #(
-                    #field_names: <#field_types as ::rustbus::Unmarshal>::unmarshal(ctx)?.1,
+                    #field_names: <#field_types as ::rustbus::Unmarshal>::unmarshal(ctx)?,
                 )*
             };
-            let total_bytes = start_len - ctx.remainder().len();
-            Ok((total_bytes, this))
+            Ok(this)
     }
 }
 fn struct_field_sigs(fields: &syn::Fields) -> TokenStream {

--- a/rustbus_derive/src/structs.rs
+++ b/rustbus_derive/src/structs.rs
@@ -50,7 +50,7 @@ pub fn make_struct_unmarshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Unmarshal<'__internal_buf, '_> for #ident #typ_gen #clause_gen {
             #[inline]
-            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal::UnmarshalContext<'_,'__internal_buf>) -> Result<(usize,Self), ::rustbus::wire::errors::UnmarshalError> {
+            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<(usize,Self), ::rustbus::wire::errors::UnmarshalError> {
                 #marshal
             }
         }
@@ -102,7 +102,7 @@ fn struct_field_unmarshal(fields: &syn::Fields) -> TokenStream {
     let field_types = fields.iter().map(|field| field.ty.to_token_stream());
 
     quote! {
-            let start_offset = ctx.offset;
+            let start_len = ctx.remainder().len();
             ctx.align_to(8)?;
 
             let this = Self{
@@ -110,7 +110,7 @@ fn struct_field_unmarshal(fields: &syn::Fields) -> TokenStream {
                     #field_names: <#field_types as ::rustbus::Unmarshal>::unmarshal(ctx)?.1,
                 )*
             };
-            let total_bytes = ctx.offset - start_offset;
+            let total_bytes = start_len - ctx.remainder().len();
             Ok((total_bytes, this))
     }
 }

--- a/rustbus_derive/src/variants.rs
+++ b/rustbus_derive/src/variants.rs
@@ -188,7 +188,7 @@ pub fn make_variant_unmarshal_impl(
             fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<(usize,Self), ::rustbus::wire::errors::UnmarshalError> {
                 let start_len = ctx.remainder().len();
                 let (sig_bytes, sig) = ctx.read_signature()?;
-                
+
                 #marshal
                 Err(::rustbus::wire::errors::UnmarshalError::NoMatchingVariantFound)
             }

--- a/rustbus_derive/src/variants.rs
+++ b/rustbus_derive/src/variants.rs
@@ -185,9 +185,8 @@ pub fn make_variant_unmarshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Unmarshal<'__internal_buf, '_> for #ident #typ_gen #clause_gen {
             #[inline]
-            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<(usize,Self), ::rustbus::wire::errors::UnmarshalError> {
-                let start_len = ctx.remainder().len();
-                let (sig_bytes, sig) = ctx.read_signature()?;
+            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<Self, ::rustbus::wire::errors::UnmarshalError> {
+                let sig = ctx.read_signature()?;
 
                 #marshal
                 Err(::rustbus::wire::errors::UnmarshalError::NoMatchingVariantFound)
@@ -226,11 +225,10 @@ fn variant_unmarshal(enum_name: syn::Ident, variant: &syn::Variant) -> TokenStre
                     ctx.align_to(8)?;
                     let this = #enum_name::#name{
                         #(
-                            #field_names: <#field_types2 as ::rustbus::Unmarshal>::unmarshal(ctx)?.1,
+                            #field_names: <#field_types2 as ::rustbus::Unmarshal>::unmarshal(ctx)?,
                         )*
                     };
-                    let total_bytes = start_len - ctx.remainder().len();
-                    return Ok((total_bytes, this));
+                    return Ok(this);
                 }
             }
         } else if variant.fields.iter().next().unwrap().ident.is_none() && variant.fields.len() > 1
@@ -248,11 +246,10 @@ fn variant_unmarshal(enum_name: syn::Ident, variant: &syn::Variant) -> TokenStre
                     ctx.align_to(8)?;
                     let this = #enum_name::#name(
                         #(
-                            <#field_types2 as ::rustbus::Unmarshal>::unmarshal(ctx)?.1,
+                            <#field_types2 as ::rustbus::Unmarshal>::unmarshal(ctx)?,
                         )*
                     );
-                    let total_bytes = start_len - ctx.remainder().len();
-                    return Ok((total_bytes, this));
+                    return Ok(this);
                 }
             }
         } else {
@@ -265,10 +262,9 @@ fn variant_unmarshal(enum_name: syn::Ident, variant: &syn::Variant) -> TokenStre
 
                 if sig.eq(sig_str.as_ref()) {
                     let this = #enum_name::#name(
-                        <#ty as ::rustbus::Unmarshal>::unmarshal(ctx)?.1,
+                        <#ty as ::rustbus::Unmarshal>::unmarshal(ctx)?,
                     );
-                    let total_bytes = start_len - ctx.remainder().len();
-                    return Ok((total_bytes, this));
+                    return Ok(this);
                 }
             }
         }

--- a/rustbus_derive_test/Cargo.toml
+++ b/rustbus_derive_test/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 "rustbus" = {path = "../rustbus", version = "0.19.3"}
-"rustbus_derive" = {path = "../rustbus_derive", version = "0.5.0"}
+"rustbus_derive" = {path = "../rustbus_derive", version = "0.6.0"}


### PR DESCRIPTION
Parsing was updating the offset of the UnmarshalContext all over the place. This PR cleans this up by making offset and buf private and adding read_xxx functions for the primitives to the UnmarshalContext, which 

* aligns itself correctly
* parses the primitive
* updates its offset

This is a big refactor and the testing seems like it could use a good cleanup itself.  