### PR TITLE
Enforce that serials are not zero

### DIFF
--- a/rustbus/benches/marshal_benchmark.rs
+++ b/rustbus/benches/marshal_benchmark.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rustbus::params::Container;
 use rustbus::params::DictMap;
@@ -9,7 +11,7 @@ use rustbus::wire::unmarshal::unmarshal_next_message;
 use rustbus::wire::unmarshal_context::Cursor;
 
 fn marsh(msg: &rustbus::message_builder::MarshalledMessage, buf: &mut Vec<u8>) {
-    marshal(msg, 0, buf).unwrap();
+    marshal(msg, NonZeroU32::MIN, buf).unwrap();
 }
 
 fn unmarshal(buf: &[u8]) {
@@ -66,7 +68,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
                 .build();
             msg.body.push_old_params(&params).unwrap();
-            msg.dynheader.serial = Some(1);
+            msg.dynheader.serial = Some(NonZeroU32::MIN);
             buf.clear();
             marsh(black_box(&msg), &mut buf)
         })
@@ -76,7 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .signal("io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
     msg.body.push_old_params(&params).unwrap();
-    msg.dynheader.serial = Some(1);
+    msg.dynheader.serial = Some(NonZeroU32::MIN);
     buf.clear();
     marsh(&msg, &mut buf);
     buf.extend_from_slice(msg.get_buf());

--- a/rustbus/src/bin/create_corpus.rs
+++ b/rustbus/src/bin/create_corpus.rs
@@ -5,6 +5,7 @@ use rustbus::message_builder::MessageBuilder;
 use rustbus::Marshal;
 
 use std::io::Write;
+use std::num::NonZeroU32;
 
 fn main() {
     make_and_dump(
@@ -60,7 +61,7 @@ fn make_message() -> MarshalledMessage {
 
 fn dump_message(path: &str, msg: &MarshalledMessage) {
     let mut hdrbuf = vec![];
-    rustbus::wire::marshal::marshal(msg, 0, &mut hdrbuf).unwrap();
+    rustbus::wire::marshal::marshal(msg, NonZeroU32::MIN, &mut hdrbuf).unwrap();
 
     let mut file = std::fs::File::create(path).unwrap();
     file.write_all(&hdrbuf).unwrap();

--- a/rustbus/src/bin/perf_test.rs
+++ b/rustbus/src/bin/perf_test.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use rustbus::connection::Timeout;
 use rustbus::MessageBuilder;
 use rustbus::RpcConn;
@@ -28,7 +30,7 @@ fn main() {
     let mut buf = Vec::new();
     for _ in 0..20000000 {
         buf.clear();
-        rustbus::wire::marshal::marshal(&sig, 1, &mut buf).unwrap();
+        rustbus::wire::marshal::marshal(&sig, NonZeroU32::MIN, &mut buf).unwrap();
     }
 
     // for _ in 0..50000000 {

--- a/rustbus/src/message_builder.rs
+++ b/rustbus/src/message_builder.rs
@@ -1,4 +1,5 @@
 //! Build new messages that you want to send over a connection
+use std::num::NonZeroU32;
 use std::os::fd::RawFd;
 
 use crate::params::message;
@@ -66,11 +67,11 @@ pub struct DynamicHeader {
     pub member: Option<String>,
     pub object: Option<String>,
     pub destination: Option<String>,
-    pub serial: Option<u32>,
+    pub serial: Option<NonZeroU32>,
     pub sender: Option<String>,
     pub signature: Option<String>,
     pub error_name: Option<String>,
-    pub response_serial: Option<u32>,
+    pub response_serial: Option<NonZeroU32>,
     pub num_fds: Option<u32>,
 }
 

--- a/rustbus/src/tests.rs
+++ b/rustbus/src/tests.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::params::Base;
 use crate::params::Param;
 use crate::wire::marshal::marshal;
@@ -40,9 +42,9 @@ fn test_marshal_unmarshal() {
     params.push(128u64.into());
     params.push(128i32.into());
 
-    msg.dynheader.serial = Some(1);
+    msg.dynheader.serial = Some(NonZeroU32::MIN);
     let mut buf = Vec::new();
-    marshal(&msg, 0, &mut buf).unwrap();
+    marshal(&msg, NonZeroU32::MIN, &mut buf).unwrap();
 
     let mut cursor = Cursor::new(&buf);
     let header = unmarshal_header(&mut cursor).unwrap();
@@ -97,13 +99,13 @@ fn test_invalid_stuff() {
     let mut msg = crate::message_builder::MessageBuilder::new()
         .signal(".......io.killing.spark", "TestSignal", "/io/killing/spark")
         .build();
-    msg.dynheader.serial = Some(1);
+    msg.dynheader.serial = Some(NonZeroU32::MIN);
     let mut buf = Vec::new();
     assert_eq!(
         Err(crate::wire::errors::MarshalError::Validation(
             crate::params::validation::Error::InvalidInterface
         )),
-        marshal(&msg, 0, &mut buf)
+        marshal(&msg, NonZeroU32::MIN, &mut buf)
     );
 
     // invalid member
@@ -114,12 +116,12 @@ fn test_invalid_stuff() {
             "/io/killing/spark",
         )
         .build();
-    msg.dynheader.serial = Some(1);
+    msg.dynheader.serial = Some(NonZeroU32::MIN);
     let mut buf = Vec::new();
     assert_eq!(
         Err(crate::wire::errors::MarshalError::Validation(
             crate::params::validation::Error::InvalidMembername
         )),
-        marshal(&msg, 0, &mut buf)
+        marshal(&msg, NonZeroU32::MIN, &mut buf)
     );
 }

--- a/rustbus/src/wire.rs
+++ b/rustbus/src/wire.rs
@@ -9,6 +9,9 @@ pub mod validate_raw;
 pub mod variant_macros;
 
 mod wrapper_types;
+
+use std::num::NonZeroU32;
+
 pub use wrapper_types::unixfd::UnixFd;
 pub use wrapper_types::ObjectPath;
 pub use wrapper_types::SignatureWrapper;
@@ -20,7 +23,7 @@ pub enum HeaderField {
     Interface(String),
     Member(String),
     ErrorName(String),
-    ReplySerial(u32),
+    ReplySerial(NonZeroU32),
     Destination(String),
     Sender(String),
     Signature(String),

--- a/rustbus/src/wire/errors.rs
+++ b/rustbus/src/wire/errors.rs
@@ -45,6 +45,9 @@ pub enum UnmarshalError {
     /// A message indicated an invalid byteorder in the header
     #[error("A message indicated an invalid byteorder in the header")]
     InvalidByteOrder,
+    /// A message has an invalid (zero) serial in the header
+    #[error("A message has an invalid (zero) serial in the header")]
+    InvalidSerial,
     /// A message indicated an invalid message type
     #[error("A message indicated an invalid message type")]
     InvalidMessageType,

--- a/rustbus/src/wire/marshal.rs
+++ b/rustbus/src/wire/marshal.rs
@@ -3,6 +3,8 @@
 //! * `base` and `container` are for the Param approach that map dbus concepts to enums/structs
 //! * `traits` is for the trait based approach
 
+use std::num::NonZeroU32;
+
 use crate::message_builder;
 use crate::params;
 use crate::wire::HeaderField;
@@ -34,7 +36,7 @@ impl MarshalContext<'_, '_> {
 /// and use get_buf() to get to the contents
 pub fn marshal(
     msg: &crate::message_builder::MarshalledMessage,
-    chosen_serial: u32,
+    chosen_serial: NonZeroU32,
     buf: &mut Vec<u8>,
 ) -> MarshalResult<()> {
     marshal_header(msg, chosen_serial, buf)?;
@@ -51,7 +53,7 @@ pub fn marshal(
 
 fn marshal_header(
     msg: &crate::message_builder::MarshalledMessage,
-    chosen_serial: u32,
+    chosen_serial: NonZeroU32,
     buf: &mut Vec<u8>,
 ) -> MarshalResult<()> {
     let byteorder = msg.body.byteorder();
@@ -84,7 +86,7 @@ fn marshal_header(
     // Zero bytes where the length of the message will be put
     buf.extend_from_slice(&[0, 0, 0, 0]);
 
-    write_u32(chosen_serial, byteorder, buf);
+    write_u32(chosen_serial.get(), byteorder, buf);
 
     // Zero bytes where the length of the header fields will be put
     let pos = buf.len();
@@ -172,7 +174,7 @@ fn marshal_header_field(
             buf.push(b'u');
             buf.push(0);
             pad_to_align(4, buf);
-            write_u32(*rs, byteorder, buf);
+            write_u32(rs.get(), byteorder, buf);
         }
         HeaderField::Destination(dest) => {
             params::validate_busname(dest)?;


### PR DESCRIPTION
From the spec:
> 2nd UINT32 - The serial of this message, used as a cookie by the
> sender to identify the reply corresponding to this request. This must
> not be zero.