### PR TITLE
qualify path to Result type in the derive macro quotes

### DIFF
--- a/rustbus_derive/src/structs.rs
+++ b/rustbus_derive/src/structs.rs
@@ -12,7 +12,7 @@ pub fn make_struct_marshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Marshal for #ident #typ_gen #clause_gen {
             #[inline]
-            fn marshal(&self, ctx: &mut ::rustbus::wire::marshal::MarshalContext<'_,'_>) -> Result<(), ::rustbus::wire::errors::MarshalError> {
+            fn marshal(&self, ctx: &mut ::rustbus::wire::marshal::MarshalContext<'_,'_>) -> ::core::result::Result<(), ::rustbus::wire::errors::MarshalError> {
                 #marshal
             }
         }
@@ -50,7 +50,7 @@ pub fn make_struct_unmarshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Unmarshal<'__internal_buf, '_> for #ident #typ_gen #clause_gen {
             #[inline]
-            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<Self, ::rustbus::wire::errors::UnmarshalError> {
+            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> ::core::result::Result<Self, ::rustbus::wire::errors::UnmarshalError> {
                 #marshal
             }
         }

--- a/rustbus_derive/src/variants.rs
+++ b/rustbus_derive/src/variants.rs
@@ -37,7 +37,7 @@ pub fn make_variant_marshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Marshal for #ident #typ_gen #clause_gen {
             #[inline]
-            fn marshal(&self, ctx: &mut ::rustbus::wire::marshal::MarshalContext<'_,'_>) -> Result<(), ::rustbus::wire::errors::MarshalError> {
+            fn marshal(&self, ctx: &mut ::rustbus::wire::marshal::MarshalContext<'_,'_>) -> ::core::result::Result<(), ::rustbus::wire::errors::MarshalError> {
                 match self {
                     #marshal
                 }
@@ -185,7 +185,7 @@ pub fn make_variant_unmarshal_impl(
     quote! {
         impl #impl_gen ::rustbus::Unmarshal<'__internal_buf, '_> for #ident #typ_gen #clause_gen {
             #[inline]
-            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> Result<Self, ::rustbus::wire::errors::UnmarshalError> {
+            fn unmarshal(ctx: &mut ::rustbus::wire::unmarshal_context::UnmarshalContext<'_,'__internal_buf>) -> ::core::result::Result<Self, ::rustbus::wire::errors::UnmarshalError> {
                 let sig = ctx.read_signature()?;
 
                 #marshal


### PR DESCRIPTION
Unqualified references to `Result` can cause problems when the user shadows the `Result` type in their own crate.

For example:

```rust
type Result<T> = std::result::Result<T, rustbus::connection::Error>;

#[derive(Debug, Clone, rustbus::Signature, rustbus::Unmarshal)]
struct SystemdUnitDescription {
    name: String,
    description: String,
    load_state: String,
    active_state: String,
    sub_state: String,
    followed: String,
    path: ObjectPath<String>,
    job_id: u32,
    job_type: String,
    job_path: ObjectPath<String>,
}
```
```
error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
  --> src/systemd.rs:97:44
   |
97 | #[derive(Debug, Clone, rustbus::Signature, rustbus::Unmarshal)]
   |                                            ^^^^^^^^^^^^^^^^^^
   |                                            |
   |                                            expected 1 generic argument
   |                                            help: remove this generic argument
   |
note: type alias defined here, with 1 generic parameter: `T`
  --> src/systemd.rs:95:6
   |
95 | type Result<T> = std::result::Result<T, rustbus::connection::Error>;
   |      ^^^^^^ -
   = note: this error originates in the derive macro `rustbus::Unmarshal` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0107`.
error: could not compile `dbus-experiments` (bin "dbus-experiments") due to previous error

```